### PR TITLE
Use React of the parent project instead of our own

### DIFF
--- a/packages/react-notion-x/package.json
+++ b/packages/react-notion-x/package.json
@@ -29,8 +29,6 @@
     "prismjs": "^1.20.0",
     "rc-dropdown": "^3.1.2",
     "rc-menu": "^8.5.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-image": "^4.0.3",
     "react-lazy-images": "^1.1.0",
     "react-modal": "^3.11.2",
@@ -44,9 +42,13 @@
     "@types/node": "^14.6.0",
     "@types/react": "^16.9.46",
     "@types/react-modal": "^3.10.5",
-    "@types/react-pdf": "^4.0.5"
+    "@types/react-pdf": "^4.0.5",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "peerDependencies": {
-    "next": "^9.5.3"
+    "next": "^9.5.3",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   }
 }


### PR DESCRIPTION
`react-notion-x` should not use its own React, but its parent's, as using two different React copies might cause problems. While usually package managers deduplicate dependencies, in some cases they might choose not to (and the semantics of `node`'s package system don't force them to deduplicate either). Declaring `react` and `react-dom` as peer dependencies will make clear that they have to use the parent's copy, and declaring it in the `devDependencies` will make sure that they are available for local development and testing.

<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->