### PR TITLE
+ activeUser for accounts with multiple workspaces

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -12,9 +12,9 @@ import * as types from './types'
 export class NotionAPI {
   private readonly _apiBaseUrl: string
   private readonly _authToken?: string
+  private readonly _activeUser?: string
   private readonly _userLocale: string
   private readonly _userTimeZone: string
-  private readonly _activeUser: string
 
   constructor({
     apiBaseUrl = 'https://www.notion.so/api/v3',

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -21,7 +21,7 @@ export class NotionAPI {
     authToken,
     userLocale = 'en',
     userTimeZone = 'America/New_York',
-    activeUser = undefined
+    activeUser
   }: {
     apiBaseUrl?: string
     authToken?: string

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -19,9 +19,9 @@ export class NotionAPI {
   constructor({
     apiBaseUrl = 'https://www.notion.so/api/v3',
     authToken,
+    activeUser,
     userLocale = 'en',
-    userTimeZone = 'America/New_York',
-    activeUser
+    userTimeZone = 'America/New_York'
   }: {
     apiBaseUrl?: string
     authToken?: string
@@ -31,9 +31,9 @@ export class NotionAPI {
   } = {}) {
     this._apiBaseUrl = apiBaseUrl
     this._authToken = authToken
+    this._activeUser = activeUser
     this._userLocale = userLocale
     this._userTimeZone = userTimeZone
-    this._activeUser = activeUser
   }
 
   public async getPage(

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -20,7 +20,8 @@ export class NotionAPI {
     apiBaseUrl = 'https://www.notion.so/api/v3',
     authToken,
     userLocale = 'en',
-    userTimeZone = 'America/New_York'
+    userTimeZone = 'America/New_York',
+    activeUser = undefined
   }: {
     apiBaseUrl?: string
     authToken?: string

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -14,6 +14,7 @@ export class NotionAPI {
   private readonly _authToken?: string
   private readonly _userLocale: string
   private readonly _userTimeZone: string
+  private readonly _activeUser: string
 
   constructor({
     apiBaseUrl = 'https://www.notion.so/api/v3',
@@ -25,11 +26,13 @@ export class NotionAPI {
     authToken?: string
     userLocale?: string
     userTimeZone?: string
+    activeUser?: string
   } = {}) {
     this._apiBaseUrl = apiBaseUrl
     this._authToken = authToken
     this._userLocale = userLocale
     this._userTimeZone = userTimeZone
+    this._activeUser = activeUser
   }
 
   public async getPage(
@@ -368,6 +371,10 @@ export class NotionAPI {
 
     if (this._authToken) {
       headers.cookie = `token_v2=${this._authToken}`
+    }
+
+    if (this._activeUser) {
+      headers['x-notion-active-user-header'] = this._activeUser
     }
 
     const url = `${this._apiBaseUrl}/${endpoint}`


### PR DESCRIPTION
I tried ``notion-client`` on a server project, with authToken getPage() was giving Me ``Notion page not found`` on a page on other workspace I'm a member of.
After I inspected notion.so in Devtools, I found out that a ``x-notion-active-user-header`` header is added to the request. I implemented this by changing your code locally, and it worked.