### PR TITLE
Update styles.css changed svg.notion-page-icon to object-fit: fill

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -503,7 +503,7 @@ img.notion-page-icon-offset {
 img.notion-page-icon,
 svg.notion-page-icon {
   display: block;
-  object-fit: cover;
+  object-fit: fill;
   border-radius: 3px;
   /* padding: 1px; */
   max-width: 22px;


### PR DESCRIPTION
change object-fit in svg.notion-page-icon

using object-fit cover
![image](https://user-images.githubusercontent.com/5190412/103483547-ce9a1580-4dc6-11eb-8069-302cf2b8c164.png)

using object-fit fill
![image](https://user-images.githubusercontent.com/5190412/103483565-ea9db700-4dc6-11eb-85bc-ad405275e2b7.png)
