### PR TITLE
Detect if an anchor link is external and link set rel and target accordingly

### DIFF
--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -134,7 +134,7 @@ export const Text: React.FC<{
               return <Equation math={decorator[1]} />
 
             case 'a':
-              const isExternalLink = !!linkProtocol;
+              const isExternalLink = !!linkProtocol
 
               return (
                 <components.link

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -134,9 +134,13 @@ export const Text: React.FC<{
               return <Equation math={decorator[1]} />
 
             case 'a':
+              const isExternalLink = !!linkProtocol;
+
               return (
                 <components.link
                   className='notion-link'
+                  target={isExternalLink ? `_blank` : `_self`}
+                  rel={isExternalLink ? `noopener noreferrer` : ``}
                   href={
                     linkProtocol
                       ? `${linkProtocol}:${decorator[1]}`


### PR DESCRIPTION
With this PR we we check whether an anchor links to an internal or external page. On our notion page we use a links to link a internal pages. 

Example https://service-zonneplan.vercel.app/b5830d7f3bd04a7788b819461a998b69 with the links "Ga naar". We use a link instead of pageLink because we want to have the link a different title than the page itself. 

The check is pretty simple; if the anchor contains http or https, we decided that is is in an external page.