### PR TITLE
Typer Error cannot read property 'title' of undefined

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -685,7 +685,7 @@ export const Block: React.FC<BlockProps> = (props) => {
               <div className='notion-bookmark-image'>
                 <GracefulImage
                   src={block.format?.bookmark_cover}
-                  alt={getTextContent(block.properties.title)}
+                  alt={getTextContent(block.properties?.title)}
                   loading='lazy'
                 />
               </div>
@@ -698,7 +698,7 @@ export const Block: React.FC<BlockProps> = (props) => {
       return (
         <details className={cs('notion-toggle', blockId)}>
           <summary>
-            <Text value={block.properties.title} block={block} />
+            <Text value={block.properties?.title} block={block} />
           </summary>
 
           <div>{children}</div>


### PR DESCRIPTION
Fix empty Notion toggles and possible empty image titles

Public notion page example: https://www.notion.so/Test-Empty-130868ef58d949f4add8cf1da983fc16
Id: 130868ef58d949f4add8cf1da983fc16

With out this change the above notion page would get the error:

Typer Error cannot read property 'title' of undefined

![image](https://user-images.githubusercontent.com/21371266/108309315-2cf83900-7166-11eb-95d4-0a5652a47e2d.png)
