### PR TITLE
fixed filter possibly being undefined in collection card

### DIFF
--- a/packages/react-notion-x/src/components/collection-card.tsx
+++ b/packages/react-notion-x/src/components/collection-card.tsx
@@ -82,7 +82,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
     const schema = collection.schema[property]
     const data = block.properties?.[property]
 
-    if (schema) {
+    if (schema && data) {
       if (schema.type === 'file') {
         const files = data
           .filter((v) => v.length === 2)


### PR DESCRIPTION
`
TypeError: Cannot read property 'filter' of undefined
    at CollectionCard (/Users/noahbragg/Developer/node_projects/potion/potion-site-v2/node_modules/react-notion-x/build/cjs/components/collection-card.js:83:22)
`

Happens on this page: https://www.notion.so/ad83934d2fe94e8dba592c8547d6a026?v=7a75440935c44dc88e4dcfcf2b87f28f