### PR TITLE
fixed block.properties being undefined in collection-card

### DIFF
--- a/packages/react-notion-x/src/components/collection-card.tsx
+++ b/packages/react-notion-x/src/components/collection-card.tsx
@@ -108,7 +108,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
       }
     }
   }
-
+  
   return (
     <NotionContextProvider
       {...ctx}
@@ -151,6 +151,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
                 collection.schema[p.property]
             )
             .map((p) => {
+              if(!block.properties) return null
               const schema = collection.schema[p.property]
               const data = block.properties[p.property]
 

--- a/packages/react-notion-x/src/components/collection-card.tsx
+++ b/packages/react-notion-x/src/components/collection-card.tsx
@@ -108,7 +108,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
       }
     }
   }
-  
+
   return (
     <NotionContextProvider
       {...ctx}
@@ -151,7 +151,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
                 collection.schema[p.property]
             )
             .map((p) => {
-              if(!block.properties) return null
+              if (!block.properties) return null
               const schema = collection.schema[p.property]
               const data = block.properties[p.property]
 


### PR DESCRIPTION
This issue is related to the last PR in a case when properties is null. Just skipping that property when there is no data.

Happens on this page: https://www.notion.so/ad83934d2fe94e8dba592c8547d6a026?v=7a75440935c44dc88e4dcfcf2b87f28f

![image](https://user-images.githubusercontent.com/21371266/108898858-947e1080-75cc-11eb-9850-f1b7b8e15171.png)

