### PR TITLE
fixed width for columns in browsers such as safari

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -574,7 +574,7 @@ export const Block: React.FC<BlockProps> = (props) => {
 
       const width = `calc((100% - (${
         columns - 1
-      } * ${spacerWidth}px)) * ${ratio})`
+      } * ${spacerWidth})) * ${ratio})`
       const style = { width }
 
       return (


### PR DESCRIPTION
Fixed columns for safari and other browsers.

Notion page id for example: 067dd719a912471ea9a3ac10710e7fdf

After some playing around I found that px was causing safari to fail calculating the width where as chrome was smarter than that. 😂
