### PR TITLE
Fixed minTableOfContentsItems not working.

### DIFF
--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -93,6 +93,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
       previewImages={previewImages}
       showCollectionViewDropdown={showCollectionViewDropdown}
       showTableOfContents={showTableOfContents}
+      minTableOfContentsItems={minTableOfContentsItems}
       defaultPageIcon={defaultPageIcon}
       defaultPageCover={defaultPageCover}
       defaultPageCoverPosition={defaultPageCoverPosition}


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
`minTableOfContentsItems` in props was not working properly.


I think I'll be able to change `minTableOfContentsItems = 3`.

https://github.com/transitive-bullshit/nextjs-notion-starter-kit/blob/a1f240931536d30c225741c38087d66b85e5f0c5/components/NotionPage.tsx#L128

test
https://www.notion.so/suu35/TableOfContents-f5dc8b907d2e427b830836d8f78c0a41