### PR TITLE
YouTube Video Url has "youtube.com" and "youtu.be"

### DIFF
--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -140,6 +140,7 @@ export const Asset: React.FC<{
       block.type === 'video' &&
       signedUrl &&
       signedUrl.indexOf('youtube') < 0 &&
+      signedUrl.indexOf('youtu.be') < 0 &&
       signedUrl.indexOf('vimeo') < 0
     ) {
       content = (


### PR DESCRIPTION
Video assets url has two youtube url type ,  "youtube.com" and "youtu.be".
if url has "youtu.be", display iframe.

test with this page please.
https://www.notion.so/nabettu/youtube-test-cf528ab5f3374ada859cfa9ea450fad9