### PR TITLE
Added links to pages in table rows

### DIFF
--- a/packages/react-notion-x/src/components/property.tsx
+++ b/packages/react-notion-x/src/components/property.tsx
@@ -24,7 +24,7 @@ export const Property: React.FC<{
   collection?: types.Collection
   inline?: boolean
 }> = ({ schema, data, block, collection, inline = false }) => {
-  const { components, mapImageUrl } = useNotionContext()
+  const { components, mapImageUrl, mapPageUrl } = useNotionContext()
 
   if (schema) {
     let content = null
@@ -73,7 +73,14 @@ export const Property: React.FC<{
 
         case 'title':
           if (block) {
-            content = <PageTitle block={block} />
+            content = (
+              <components.pageLink
+                className={cs('notion-page-link')}
+                href={mapPageUrl(block.id)}
+              >
+                <PageTitle block={block} />
+              </components.pageLink>
+            )
           } else {
             content = <Text value={data} block={block} />
           }


### PR DESCRIPTION
Currently react-notion-x doesn't have pages for each row in a table. I added linking to a page in a table collection view.
Here is a little video showing the new functionality: https://www.loom.com/share/15cd7ec66aaf466eb0e6699812e1cd85

This more closely matches how Notion behaves with tables.

Tested on e5b45193b4c1436fbde24cad8e9ababd has a table in there among other things.
