### PR TITLE
fix get text to exclude marks for TeX and mention

### DIFF
--- a/packages/notion-utils/src/get-text-content.ts
+++ b/packages/notion-utils/src/get-text-content.ts
@@ -10,7 +10,7 @@ export const getTextContent = (text?: types.Decoration[]): string => {
   if (!text) {
     return ''
   } else if (Array.isArray(text)) {
-    return text?.reduce((prev, current) => prev + current[0], '') ?? ''
+    return text?.reduce((prev, current) => prev + ((current[0] !== '⁍' && current[0] !== '‣') ? current[0] : ''), '') ?? ''
   } else {
     return text
   }


### PR DESCRIPTION
A text content in Notion may include '⁍' for TeX equations and '‣' for mentions. So I changed the code a little bit to exclude this two marks. The `getTextContent` function is used in may places like toc, formula, title of collection, etc. This commit will make those elements display better.

Sample Notin Page ID: e2e6389a160e406d88e312f12ede26e4

By the way, I really appreciate your remarkable work! Just started to use react-notion-x, I hope I can contribute a little bit to this great project.