### PR TITLE
Added alt text to images from the caption

### DIFF
--- a/packages/react-notion-x/src/components/lazy-image.tsx
+++ b/packages/react-notion-x/src/components/lazy-image.tsx
@@ -98,6 +98,7 @@ export const LazyImage: React.FC<{
         src={src}
         ref={attachZoomRef}
         loading='lazy'
+        alt={alt}
         decoding='async'
         {...rest}
       />


### PR DESCRIPTION
Alt text from a caption just wasn't added to the image in lazy-image. Added it in this PR.
The preview image was already good to go.

Can see it tested out in the test suite page id: 3492bd6dbaf44fe7a5cac62c5d402f06

<img src="https://user-images.githubusercontent.com/21371266/115830398-14eea100-a3c5-11eb-8de1-f92779c9844e.png" width="50%" />

<img src="https://user-images.githubusercontent.com/21371266/115830381-0dc79300-a3c5-11eb-89dc-52398db51479.png" width="50%" />
