### PR TITLE
Fix text being empty when there is a comment on the block.

### DIFF
--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -24,7 +24,7 @@ export const Text: React.FC<{
   inline?: boolean // TODO: currently unused
 }> = ({ value, block, linkProps, linkProtocol }) => {
   const { components, recordMap, mapPageUrl, mapImageUrl } = useNotionContext()
-  
+
   return (
     <React.Fragment>
       {value?.map(([text, decorations], index) => {
@@ -92,12 +92,12 @@ export const Text: React.FC<{
 
                 default: {
                   const linkedBlock = recordMap.block[id]?.value
-                  
+
                   if (!linkedBlock) {
                     console.log('"‣" missing block', linkType, id)
                     return null
                   }
-                  
+
                   return (
                     <components.pageLink
                       className='notion-link'

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -24,7 +24,7 @@ export const Text: React.FC<{
   inline?: boolean // TODO: currently unused
 }> = ({ value, block, linkProps, linkProtocol }) => {
   const { components, recordMap, mapPageUrl, mapImageUrl } = useNotionContext()
-
+  
   return (
     <React.Fragment>
       {value?.map(([text, decorations], index) => {
@@ -92,12 +92,12 @@ export const Text: React.FC<{
 
                 default: {
                   const linkedBlock = recordMap.block[id]?.value
-
+                  
                   if (!linkedBlock) {
                     console.log('"‣" missing block', linkType, id)
                     return null
                   }
-
+                  
                   return (
                     <components.pageLink
                       className='notion-link'
@@ -136,7 +136,7 @@ export const Text: React.FC<{
 
             case 'm':
               // comment / discussion
-              return null
+              return element  //still need to return the base element
 
             case 'a': {
               const v = decorator[1]


### PR DESCRIPTION
Here is a page to test where I saw the issue: 4d967aaf8f204b30a0f50c74f2801987

You can see down about half way the FAQ title and first title of the toggle aren't showing. I found this was because the page had comments there.

<img src="https://user-images.githubusercontent.com/21371266/116796092-be512900-aa8e-11eb-90e0-a508176a4a4b.png" width="50%" />

The change I made was make the "m" decoration (comments) still return the element instead of skipping it.

