### PR TITLE
fix property error if no language is set in code block

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -547,7 +547,7 @@ export const Block: React.FC<BlockProps> = (props) => {
     case 'code': {
       if (block.properties.title) {
         const content = block.properties.title[0][0]
-        const language = block.properties.language[0][0]
+        const language = block.properties.language ? block.properties.language[0][0] : ''
 
         // TODO: add className
         return (


### PR DESCRIPTION
If no language is set in notion code block, this line will yield an error:

```
Cannot read property '0' of undefined
```

See https://github.com/craigary/nobelium/issues/130

