### PR TITLE
Comment out debug logs of collection views

### DIFF
--- a/packages/react-notion-x/src/components/collection-view-board.tsx
+++ b/packages/react-notion-x/src/components/collection-view-board.tsx
@@ -21,7 +21,7 @@ export const CollectionViewBoard: React.FC<CollectionViewProps> = ({
     board_cover_aspect = 'cover'
   } = collectionView.format || {}
 
-  console.log('board', { collection, collectionView, collectionData })
+  // console.log('board', { collection, collectionView, collectionData })
 
   return (
     <div className='notion-board'>

--- a/packages/react-notion-x/src/components/collection-view-gallery.tsx
+++ b/packages/react-notion-x/src/components/collection-view-gallery.tsx
@@ -18,7 +18,7 @@ export const CollectionViewGallery: React.FC<CollectionViewProps> = ({
     gallery_cover_aspect = 'cover'
   } = collectionView.format || {}
 
-  console.log('gallery', { collection, collectionView, collectionData })
+  // console.log('gallery', { collection, collectionView, collectionData })
 
   return (
     <div className='notion-gallery'>

--- a/packages/react-notion-x/src/components/collection-view-list.tsx
+++ b/packages/react-notion-x/src/components/collection-view-list.tsx
@@ -11,7 +11,7 @@ export const CollectionViewList: React.FC<CollectionViewProps> = ({
   collectionData
 }) => {
   const { components, recordMap, mapPageUrl } = useNotionContext()
-  console.log('list', { collection, collectionView, collectionData })
+  // console.log('list', { collection, collectionView, collectionData })
 
   return (
     <div className='notion-list-collection'>

--- a/packages/react-notion-x/src/components/collection-view-table.tsx
+++ b/packages/react-notion-x/src/components/collection-view-table.tsx
@@ -14,7 +14,7 @@ export const CollectionViewTable: React.FC<CollectionViewProps> = ({
   width
 }) => {
   const { recordMap } = useNotionContext()
-  console.log('table', { collection, collectionView, collectionData })
+  // console.log('table', { collection, collectionView, collectionData })
 
   let properties = []
 


### PR DESCRIPTION
Not sure it is intended, collection view components print out some debugging info on browsers or server logs. Hope it is able to control its verbose level in the future. Gently suggesting commenting those out in production.

![image](https://user-images.githubusercontent.com/538584/119209831-ece97f00-bae3-11eb-9377-60ed6258a152.png)
![image](https://user-images.githubusercontent.com/538584/119209854-0f7b9800-bae4-11eb-8442-2d8b06e4d691.png)
