### PR TITLE
fixed groupBlockContent trying to access index -1

### DIFF
--- a/packages/react-notion-x/src/utils.ts
+++ b/packages/react-notion-x/src/utils.ts
@@ -24,8 +24,10 @@ const groupBlockContent = (blockMap: BlockMap): string[][] => {
           lastType = blockType
           output[index] = []
         }
-
-        output[index].push(blockId)
+        
+        if (index > -1) {
+          output[index].push(blockId)
+        }
       })
     }
 


### PR DESCRIPTION
Interesting issue in grouping block content where a block is missing so the value is undefined. Somehow its getting past the null check so then trys to access the array at index -1

happening on this notion page: b1e94e2308b24476a323fcaa6fa1a906
