### PR TITLE
Update collection property_visibility type.

### DIFF
--- a/packages/notion-types/src/collection.ts
+++ b/packages/notion-types/src/collection.ts
@@ -46,7 +46,7 @@ export interface Collection {
     }>
     property_visibility?: Array<{
       property: PropertyID
-      visibility: 'show' | 'hide'
+      visibility: 'show' | 'hide' | 'hide_if_empty'
     }>
   }
 }


### PR DESCRIPTION
collection visibility has "hide_if_empty".

<img width="455" alt="スクリーンショット 2021-05-31 9 32 12" src="https://user-images.githubusercontent.com/5053646/120125317-409a4d80-c1f3-11eb-8bfe-0ccc72117599.png">

### Test Page
https://www.notion.so/nabettu/Page-1-9246e732a60a43c9abc367414b557dca

<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
