### PR TITLE
Added captions for code blocks

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -316,7 +316,8 @@ export interface CodeBlock extends BaseBlock {
   type: 'code'
   properties: {
     title: Decoration[]
-    language: Decoration[]
+    language: Decoration[],
+    caption: Decoration[]
   }
 }
 

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -550,14 +550,22 @@ export const Block: React.FC<BlockProps> = (props) => {
         const language = block.properties.language
           ? block.properties.language[0][0]
           : ''
+        const caption = block.properties.caption
 
         // TODO: add className
         return (
-          <components.code
-            key={block.id}
-            language={language || ''}
-            code={content}
-          />
+          <>
+            <components.code
+              key={block.id}
+              language={language || ''}
+              code={content}
+            />
+            {caption && (
+              <figcaption className='notion-asset-caption'>
+                <Text value={caption} block={block} />
+              </figcaption>
+            )}
+          </>
         )
       }
       break


### PR DESCRIPTION
Here is a notion page id to test on: 54ffff21b193431f98651dc2d776ab34
Just adds the caption to the code block if there is one.

![image](https://user-images.githubusercontent.com/21371266/120376838-32226380-c2d1-11eb-80c7-87084b978954.png)
The text right underneath the block is a caption in this image.
