### PR TITLE
Fixed board collection in toggle causing crash

### DIFF
--- a/packages/react-notion-x/src/components/collection-view-board.tsx
+++ b/packages/react-notion-x/src/components/collection-view-board.tsx
@@ -37,6 +37,9 @@ export const CollectionViewBoard: React.FC<CollectionViewProps> = ({
         <div className='notion-board-header'>
           <div className='notion-board-header-inner'>
             {collectionView.format.board_groups2.map((p, index) => {
+              if (!collectionData.groupResults) { //no groupResults in the data when collection is in a toggle
+                return null
+              }
               const group = collectionData.groupResults![index]
               const schema = collection.schema[p.property]
 
@@ -72,6 +75,9 @@ export const CollectionViewBoard: React.FC<CollectionViewProps> = ({
 
         <div className='notion-board-body'>
           {collectionView.format.board_groups2.map((p, index) => {
+            if (!collectionData.groupResults) {
+              return null
+            }
             const group = collectionData.groupResults![index]
             const schema = collection.schema[p.property]
 


### PR DESCRIPTION
Example of this issue on this page id: 7d3913ebc76a4ac1abc20e5a12bec55a

When the board is in a toggle the `groupResults` data is not present.
I couldn't find it anywhere else in the block either. So we aren't able to render the table when its inside a toggle.

The data without groupResults
<img width="379" alt="Screen Shot 2021-06-08 at 12 35 15 PM" src="https://user-images.githubusercontent.com/21371266/121252825-50520b80-c85d-11eb-94ba-44898d1611f0.png">
The data with groupResults
<img width="409" alt="Screen Shot 2021-06-08 at 12 35 47 PM" src="https://user-images.githubusercontent.com/21371266/121252813-4cbe8480-c85d-11eb-8c6b-6eca1eb802dd.png">


May need extra 👀 on this. But I'm not seeing away we can render the table in this case.

So for now I am return null if the `groupResults` is not there.


