### PR TITLE
Allow SSR for GracefulImage

### DIFF
--- a/packages/react-notion-x/src/components/graceful-image.tsx
+++ b/packages/react-notion-x/src/components/graceful-image.tsx
@@ -1,3 +1,12 @@
-import { Img } from 'react-image'
+import React from 'react'
+import { Img, ImgProps } from 'react-image'
+import { isBrowser } from '../utils'
 
-export const GracefulImage = Img
+export const GracefulImage = (props: ImgProps) => {
+  if(isBrowser) {
+    return <Img {...props} />
+  } else {
+    // @ts-ignore (must use the appropriate subset of props for <img> if using SSR)
+    return <img {...props} />
+  }
+}

--- a/packages/react-notion-x/src/utils.ts
+++ b/packages/react-notion-x/src/utils.ts
@@ -112,3 +112,5 @@ export const formatDate = (input: string) => {
   const month = date.getMonth()
   return `${months[month]} ${date.getDate()}, ${date.getFullYear()}`
 }
+
+export const isBrowser = typeof window !== 'undefined';


### PR DESCRIPTION
This PR updates `GracefulImage` so that when rendered in a non-browser environment it falls back to an `<img>` element instead of using react-image's `<Img>`. This allows static server rendering to correctly render images. Note that react-image deliberately does not SSR images: https://github.com/mbrevda/react-image/issues/206 (it renders nothing if only the src is provided which is how react-notion-x uses it)

In a browser the behaviour is unchanged. The props taken by `<GracefulImage` are unchanged.

Note that for simplicity the props are used as-is for the `<img>` element, and I've used a ts-ignore for this. Basically if rendering `<GracefulImage>` on the server, it acts as a plain `<img>` and only props for that tag will be relevant. I don't think it's worth doing anything more sophisticated than this yet, because all current use cases use only `<img>`-friendly tags. 

This fixes missing page + header icons when server rendering.

| Before | After |
|--------|-------|
| ![Screenshot 2021-06-12 at 21 16 02](https://user-images.githubusercontent.com/1711350/121788888-21bf9200-cbc9-11eb-9fab-3c072e2c3646.png)    | ![Screenshot 2021-06-12 at 21 18 30](https://user-images.githubusercontent.com/1711350/121788913-57647b00-cbc9-11eb-896c-26c4a0470d76.png)   |
