### PR TITLE
Added support for sync blocks

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -33,6 +33,8 @@ export type BlockType =
   | 'code'
   | 'collection_view'
   | 'collection_view_page'
+  | 'transclusion_container'
+  | 'transclusion_reference'
   // fallback for unknown blocks
   | string
 
@@ -70,6 +72,8 @@ export type Block =
   | ToggleBlock
   | CollectionViewBlock
   | CollectionViewPageBlock
+  | SyncBlock
+  | SyncPointerBlock
 
 /**
  * Base properties shared by all blocks.
@@ -331,4 +335,22 @@ export interface CollectionViewPageBlock extends BasePageBlock {
   type: 'collection_view_page'
   collection_id: ID
   view_ids: ID[]
+}
+
+export interface SyncBlock extends BaseBlock {
+  type: 'transclusion_container'
+}
+
+export interface SyncPointerBlock extends BaseBlock {
+  type: 'transclusion_reference',
+  format: {
+    copied_from_pointer: {
+      id: string,
+      spaceid: string
+    }
+    transclusion_reference_pointer: {
+      id: string,
+      spaceId: string
+    }
+  }
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -24,6 +24,7 @@ import { LazyImage } from './components/lazy-image'
 import { useNotionContext } from './context'
 import { cs, getListNumber, isUrl } from './utils'
 import { Text } from './components/text'
+import { SyncPointerBlock } from './components/sync-pointer-block'
 
 interface BlockProps {
   block: types.Block
@@ -84,7 +85,7 @@ export const Block: React.FC<BlockProps> = (props) => {
     ;(block as any).type = 'collection_view_page'
   }
 
-  const blockId = hideBlockId? 'notion-block' : `notion-block-${block.id}`
+  const blockId = hideBlockId ? 'notion-block' : `notion-block-${block.id}`
 
   switch (block.type) {
     case 'collection_view_page':
@@ -777,6 +778,12 @@ export const Block: React.FC<BlockProps> = (props) => {
           <div className='notion-to-do-children'>{children}</div>
         </div>
       )
+
+    case 'transclusion_container':
+      return <div className={cs('sync-block', blockId)}>{children}</div>
+
+    case 'transclusion_reference':
+      return <SyncPointerBlock block={block} level={level + 1} {...props} />
 
     default:
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-notion-x/src/components/sync-pointer-block.tsx
+++ b/packages/react-notion-x/src/components/sync-pointer-block.tsx
@@ -1,0 +1,35 @@
+import {
+  SyncPointerBlock as SyncPointerBlockType,
+  Block as BlockType
+} from 'notion-types'
+import React from 'react'
+
+import { NotionBlockRenderer } from '../renderer'
+
+export const SyncPointerBlock: React.FC<{
+  block: BlockType
+  level: number
+}> = (props) => {
+  let { block, level } = props
+
+  if (!block) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('missing block', block.id)
+    }
+    return null
+  }
+  const syncPointerBlock = block as SyncPointerBlockType
+  const referencePointerId =
+    syncPointerBlock?.format?.transclusion_reference_pointer.id
+  if (referencePointerId == null) return
+
+  if (referencePointerId == null) return null
+
+  return (
+    <NotionBlockRenderer
+      key={referencePointerId}
+      level={level}
+      blockId={referencePointerId}
+    />
+  )
+}

--- a/packages/react-notion-x/src/components/sync-pointer-block.tsx
+++ b/packages/react-notion-x/src/components/sync-pointer-block.tsx
@@ -10,7 +10,7 @@ export const SyncPointerBlock: React.FC<{
   block: BlockType
   level: number
 }> = (props) => {
-  let { block, level } = props
+  const { block, level } = props
 
   if (!block) {
     if (process.env.NODE_ENV !== 'production') {
@@ -20,10 +20,9 @@ export const SyncPointerBlock: React.FC<{
   }
   const syncPointerBlock = block as SyncPointerBlockType
   const referencePointerId =
-    syncPointerBlock?.format?.transclusion_reference_pointer.id
-  if (referencePointerId == null) return
+    syncPointerBlock?.format?.transclusion_reference_pointer?.id
 
-  if (referencePointerId == null) return null
+  if (!referencePointerId) return null
 
   return (
     <NotionBlockRenderer

--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -106,7 +106,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
   )
 }
 
-const NotionBlockRenderer: React.FC<NotionBlockRendererProps> = ({
+export const NotionBlockRenderer: React.FC<NotionBlockRendererProps> = ({
   level = 0,
   blockId,
   ...props


### PR DESCRIPTION
The new Notion sync block is here. Now react-notion-x can support this.

I exported the NotionBlockRenderer sot that functionality could be used for the reference blocks.

Test page on: 8bcd65801a5d450fb7218d8890a38c29

<img src="https://user-images.githubusercontent.com/21371266/122607277-2d7ae080-d02f-11eb-8d86-ae91036e85d5.png" width="50%" />
