### PR TITLE
fixed notion block className not using id

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -85,7 +85,7 @@ export const Block: React.FC<BlockProps> = (props) => {
     ;(block as any).type = 'collection_view_page'
   }
 
-  const blockId = hideBlockId ? 'notion-block' : `notion-block-${block.id}`
+  const blockId = hideBlockId ? 'notion-block' : `notion-block-${uuidToId(block.id)}`
 
   switch (block.type) {
     case 'collection_view_page':


### PR DESCRIPTION
Notion classNames were removed to using uuid instead of id like they were in the past. Reverting this back.
