### PR TITLE
Fixed search not having the right recordmap

### DIFF
--- a/packages/react-notion-x/src/components/search-dialog.tsx
+++ b/packages/react-notion-x/src/components/search-dialog.tsx
@@ -98,7 +98,7 @@ export class SearchDialog extends React.Component<{
                             <components.pageLink
                               key={result.id}
                               className={cs('result', 'notion-page-link')}
-                              href={mapPageUrl(result.block.id)}
+                              href={mapPageUrl(result.block.id, searchResult.recordMap)}
                             >
                               <PageTitle
                                 block={result.block}

--- a/packages/react-notion-x/src/types.ts
+++ b/packages/react-notion-x/src/types.ts
@@ -1,6 +1,6 @@
 import * as types from 'notion-types'
 
-export type MapPageUrl = (pageId: string) => string
+export type MapPageUrl = (pageId: string, recordMap?: types.ExtendedRecordMap | undefined) => string
 export type MapImageUrl = (url: string, block: types.Block) => string
 export type SearchNotion = (
   params: types.SearchParams


### PR DESCRIPTION
Testing on this public notion id: e8da438394ba45f19ff4469b239e23ab

Here is the problem. mapPageUrl doesn't have the correct recordMap for all the search pages. So then you can't create the correct url for search results using automatic urls for example.

So when searching you get this:
<img src="https://user-images.githubusercontent.com/21371266/122976011-c91a9280-d348-11eb-9c2c-ffbdb7f8f4d8.png" width="50%" />

Now you can pass the results recordMap in and have more info to create the results needed for mapPageUrl. So you get this now.
<img src="https://user-images.githubusercontent.com/21371266/122976131-e6e7f780-d348-11eb-9e44-35135dd8abe8.png" width="50%" />

You could create a wrapper around this to pass a generic mapPageUrl into the NotionRenderer. But that recordMap only has the pages in the recordmap for that page. It doesn't have all the nested pages of a multilayer document.

This is also backwards compatible as recordMap can be undefined.

