### PR TITLE
Use h1 instead of div for notion-title

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -232,9 +232,9 @@ export const Block: React.FC<BlockProps> = (props) => {
 
                     {pageHeader}
 
-                    <div className='notion-title'>
+                    <h1 className='notion-title'>
                       <Text value={properties?.title} block={block} />
-                    </div>
+                    </h1>
 
                     {block.type === 'page' &&
                       block.parent_table === 'collection' && (


### PR DESCRIPTION
I use react-notion-x for my personal website and it's awesome!

But I figured out an issue with the main title when using the `fullPage` option.

Example on my website: https://shellbear.me/blog/go-dokku-deployment 

<img width="1290" alt="Screenshot 2021-06-29 at 17 04 26" src="https://user-images.githubusercontent.com/20194995/123760699-11fbb980-d8fc-11eb-931a-a521f7fbb246.png">

The `notion-title` is wrapped inside a div. It should be a  `h1` instead for SEO and best practices.

If you compare with any website made with super.so, the title is always a `h1`.

Example on a random website made with super.so: https://clip.super.so/

<img width="797" alt="Screenshot 2021-06-29 at 17 06 13" src="https://user-images.githubusercontent.com/20194995/123760974-51c2a100-d8fc-11eb-91c5-0f4cfce8cbd1.png">

Thank you 👋
