### PR TITLE
fixed empty bookmark causing error

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -85,7 +85,9 @@ export const Block: React.FC<BlockProps> = (props) => {
     ;(block as any).type = 'collection_view_page'
   }
 
-  const blockId = hideBlockId ? 'notion-block' : `notion-block-${uuidToId(block.id)}`
+  const blockId = hideBlockId
+    ? 'notion-block'
+    : `notion-block-${uuidToId(block.id)}`
 
   switch (block.type) {
     case 'collection_view_page':
@@ -643,6 +645,8 @@ export const Block: React.FC<BlockProps> = (props) => {
       )
 
     case 'bookmark':
+      if (!block.properties) return null
+
       let title = getTextContent(block.properties?.title)
       if (!title) {
         title = getTextContent(block.properties?.link)


### PR DESCRIPTION
empty bookmarks cause an error because some data isn't there. Just returning null when there is no link added to the bookmark.

Also prettified some code so that was the other change.

Notion page id to test: 7f266f5bfd9f48158d4aba0245ca43cb
