### PR TITLE
Fix for board collections

### DIFF
--- a/packages/notion-client/src/notion-api.test.ts
+++ b/packages/notion-client/src/notion-api.test.ts
@@ -11,7 +11,8 @@ const pageIdFixturesSuccess = [
   'e68c18a461904eb5a2ddc3748e76b893',
   'https://www.notion.so/saasifysh/Saasify-Key-Takeaways-689a8abc1afa4699905aa2f2e585e208',
   'https://www.notion.so/saasifysh/TransitiveBullsh-it-78fc5a4b88d74b0e824e29407e9f1ec1',
-  'https://www.notion.so/saasifysh/About-8d0062776d0c4afca96eb1ace93a7538'
+  'https://www.notion.so/saasifysh/About-8d0062776d0c4afca96eb1ace93a7538',
+  'https://www.notion.so/potionsite/newest-board-a899b98b7cdc424585e5ddebbdae60cc'
 
   // collections stress test
   // NOTE: removing because of sporadic timeouts

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -126,7 +126,8 @@ export class NotionAPI {
                 query: collectionView?.query2 || collectionView?.query,
                 groups:
                   collectionView?.format?.board_groups2 ||
-                  collectionView?.format?.board_groups,
+                  collectionView?.format?.board_groups ||
+                  collectionView?.format?.board_columns,
                 gotOptions
               }
             )

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -123,7 +123,7 @@ export class NotionAPI {
               collectionViewId,
               {
                 type: collectionView?.type,
-                query: collectionView?.query2 || collectionView?.query,
+                query: this.getQuery(collectionView),
                 groups:
                   collectionView?.format?.board_groups2 ||
                   collectionView?.format?.board_groups ||
@@ -321,6 +321,18 @@ export class NotionAPI {
       },
       gotOptions
     })
+  }
+
+  //handle setting group_by for the query if it isn't already
+  private getQuery(collectionView: notion.CollectionView | undefined) {
+    let query = collectionView?.query2 || collectionView?.query
+    const groupBy = collectionView?.format?.board_columns_by
+      ? collectionView?.format?.board_columns_by?.property
+      : undefined
+    if (groupBy) {
+      query.group_by = groupBy
+    }
+    return query
   }
 
   public async getUsers(

--- a/packages/notion-types/src/collection-view.ts
+++ b/packages/notion-types/src/collection-view.ts
@@ -103,6 +103,17 @@ export interface BoardCollectionView extends BaseCollectionView {
         // TODO: needs testing for more cases
       }
     }>
+    
+    board_columns: Array<{
+      property: PropertyID
+      hidden: boolean
+      value: {
+        type: PropertyType
+        value: string
+
+        // TODO: needs testing for more cases
+      }
+    }>
   }
 }
 

--- a/packages/react-notion-x/src/components/collection-view-board.tsx
+++ b/packages/react-notion-x/src/components/collection-view-board.tsx
@@ -23,6 +23,8 @@ export const CollectionViewBoard: React.FC<CollectionViewProps> = ({
 
   // console.log('board', { collection, collectionView, collectionData })
 
+  const boardGroups = collectionView.format.board_groups2 || collectionView.format.board_columns
+
   return (
     <div className='notion-board'>
       <div
@@ -36,7 +38,7 @@ export const CollectionViewBoard: React.FC<CollectionViewProps> = ({
       >
         <div className='notion-board-header'>
           <div className='notion-board-header-inner'>
-            {collectionView.format.board_groups2.map((p, index) => {
+            {boardGroups.map((p, index) => {
               if (!collectionData.groupResults) { //no groupResults in the data when collection is in a toggle
                 return null
               }
@@ -74,7 +76,7 @@ export const CollectionViewBoard: React.FC<CollectionViewProps> = ({
         <div className='notion-board-header-placeholder' />
 
         <div className='notion-board-body'>
-          {collectionView.format.board_groups2.map((p, index) => {
+          {boardGroups.map((p, index) => {
             if (!collectionData.groupResults) {
               return null
             }


### PR DESCRIPTION
Testing on: https://www.notion.so/potionsite/newest-board-a899b98b7cdc424585e5ddebbdae60cc

Issue: https://github.com/NotionX/react-notion-x/issues/104

Looks like Notion changed the name in collectionview.format from board_groups2 to board_columns.
We grab the queryCollection data and add it on to the recordMap. That notion endpoint was failing because it didn't have the right query params with the name change.
