### PR TITLE
added h2 h3 and h4 tags for notion header blocks

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -395,18 +395,21 @@ export const Block: React.FC<BlockProps> = (props) => {
         indentLevelClass = `notion-h-indent-${indentLevel}`
       }
 
-      return (
-        <h3
-          className={cs(
-            block.type === 'header' && 'notion-h notion-h1',
-            block.type === 'sub_header' && 'notion-h notion-h2',
-            block.type === 'sub_sub_header' && 'notion-h notion-h3',
-            blockColor && `notion-${blockColor}`,
-            indentLevelClass,
-            blockId
-          )}
-          data-id={id}
-        >
+      const isH1 = block.type === 'header'
+      const isH2 = block.type === 'sub_header'
+      const isH3 = block.type === 'sub_sub_header'
+
+      const classNameStr = cs(
+        isH1 && 'notion-h notion-h1',
+        isH2 && 'notion-h notion-h2',
+        isH3 && 'notion-h notion-h3',
+        blockColor && `notion-${blockColor}`,
+        indentLevelClass,
+        blockId
+      )
+
+      const innerHeader = (
+        <span>
           <div id={id} className='notion-header-anchor' />
 
           <a className='notion-hash-link' href={`#${id}`} title={title}>
@@ -416,8 +419,29 @@ export const Block: React.FC<BlockProps> = (props) => {
           <span className='notion-h-title'>
             <Text value={block.properties.title} block={block} />
           </span>
-        </h3>
+        </span>
       )
+
+      //page title takes the h1 so all header blocks are greater
+      if (isH1) {
+        return (
+          <h2 className={classNameStr} data-id={id}>
+            {innerHeader}
+          </h2>
+        )
+      } else if (isH2) {
+        return (
+          <h3 className={classNameStr} data-id={id}>
+            {innerHeader}
+          </h3>
+        )
+      } else {
+        return (
+          <h4 className={classNameStr} data-id={id}>
+            {innerHeader}
+          </h4>
+        )
+      }
     }
 
     case 'divider':


### PR DESCRIPTION
NotionId to test on: 067dd719a912471ea9a3ac10710e7fdf

Updated the Notion subheader blocks to have h2 h3 annd h4 tags for better seo.

The notion page title already takes the h1 tag so...
Notion h1 block -> h2 tag
Notion h2 block -> h3 tag
Notion h3 block -> h4 tag

added the new tags in a way that the previous header style classes shouldn't be affected and there shouldn't be any breaking style changes.

Possible that we won't want the tags to wrap as much content and be closer to the text itself? This seems good enough though.

![image](https://user-images.githubusercontent.com/21371266/127043176-0d95895f-ac18-49c5-b42c-1f6448376be3.png)

