### PR TITLE
added support for google sheets embed, added asset wrapper component

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -306,7 +306,7 @@ export interface FileBlock extends BaseBlock {
   file_ids?: string[]
 }
 
-export interface GoogleDriveBlock extends BaseBlock {
+export interface GoogleDriveBlock extends BaseContentBlock {
   type: 'drive'
   format: {
     drive_status: {
@@ -323,7 +323,14 @@ export interface GoogleDriveBlock extends BaseBlock {
       thumbnail: string
       user_name: string
       modified_time: number
-    }
+    },
+    block_width: number
+    block_height: number
+    display_source: string
+    block_full_width: boolean
+    block_page_width: boolean
+    block_aspect_ratio: number
+    block_preserve_scale: boolean
   }
   file_ids?: string[]
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -9,7 +9,6 @@ import {
 } from 'notion-utils'
 import * as types from 'notion-types'
 
-import { Asset } from './components/asset'
 import { Checkbox } from './components/checkbox'
 import { PageIcon } from './components/page-icon'
 import { PageTitle } from './components/page-title'
@@ -25,6 +24,7 @@ import { useNotionContext } from './context'
 import { cs, getListNumber, isUrl } from './utils'
 import { Text } from './components/text'
 import { SyncPointerBlock } from './components/sync-pointer-block'
+import { AssetWrapper } from './components/asset-wrapper'
 
 interface BlockProps {
   block: types.Block
@@ -535,28 +535,17 @@ export const Block: React.FC<BlockProps> = (props) => {
     case 'embed':
     // fallthrough
     case 'video':
-      const value = block as types.BaseContentBlock
-
-      return (
-        <figure
-          className={cs(
-            'notion-asset-wrapper',
-            `notion-asset-wrapper-${block.type}`,
-            block.format?.block_full_width && 'notion-asset-wrapper-full',
-            blockId
-          )}
-        >
-          <Asset block={block} />
-
-          {value?.properties?.caption && (
-            <figcaption className='notion-asset-caption'>
-              <Text value={block.properties.caption} block={block} />
-            </figcaption>
-          )}
-        </figure>
-      )
+      return <AssetWrapper blockId={blockId} block={block} />
 
     case 'drive':
+      const properties = block.format?.drive_properties
+      if (!properties) {
+        //check if this drive actually needs to be embeded ex. google sheets.
+        if (block.format?.display_source) {
+          return <AssetWrapper blockId={blockId} block={block} />
+        }
+      }
+
       return (
         <GoogleDrive
           block={block as types.GoogleDriveBlock}

--- a/packages/react-notion-x/src/components/asset-wrapper.tsx
+++ b/packages/react-notion-x/src/components/asset-wrapper.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { BaseContentBlock, Block } from 'notion-types'
+import { Asset } from './asset'
+import { cs } from '../utils'
+import { Text } from './text'
+
+export const AssetWrapper: React.FC<{
+  blockId: string
+  block: Block
+}> = ({ blockId, block }) => {
+  const value = block as BaseContentBlock
+
+  return (
+    <figure
+      className={cs(
+        'notion-asset-wrapper',
+        `notion-asset-wrapper-${block.type}`,
+        value.format?.block_full_width && 'notion-asset-wrapper-full',
+        blockId
+      )}
+    >
+      <Asset block={value} />
+
+      {value?.properties?.caption && (
+        <figcaption className='notion-asset-caption'>
+          <Text value={block.properties.caption} block={block} />
+        </figcaption>
+      )}
+    </figure>
+  )
+}

--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -18,7 +18,8 @@ const types = [
   'tweet',
   'pdf',
   'gist',
-  'codepen'
+  'codepen',
+  'drive'
 ]
 
 export const Asset: React.FC<{
@@ -136,7 +137,8 @@ export const Asset: React.FC<{
     block.type === 'gist' ||
     block.type === 'maps' ||
     block.type === 'excalidraw' ||
-    block.type === 'codepen'
+    block.type === 'codepen' ||
+    block.type === 'drive'
   ) {
     const signedUrl = recordMap.signed_urls[block.id]
 


### PR DESCRIPTION
Notion page id to test: 5d3638cec4a54a38848af636c5dd3935

Test both a google sheet embed as well as a google drive.

Created the AssetWrapper so there isn't duplicate code around assets.
![image](https://user-images.githubusercontent.com/21371266/127232402-f3a7a82c-a1fe-4726-9d08-a8123728a2ee.png)
