### PR TITLE
fix sync block width not being full width

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -799,7 +799,7 @@ export const Block: React.FC<BlockProps> = (props) => {
       )
 
     case 'transclusion_container':
-      return <div className={cs('sync-block', blockId)}>{children}</div>
+      return <div className={cs('notion-sync-block', blockId)}>{children}</div>
 
     case 'transclusion_reference':
       return <SyncPointerBlock block={block} level={level + 1} {...props} />

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2370,3 +2370,7 @@ svg.notion-page-icon {
 .notion-search .resultsPane .result:active {
   background: rgba(55, 53, 47, 0.16) !important;
 }
+
+.notion-sync-block {
+  width: 100%;
+}


### PR DESCRIPTION
example: https://potionsite.notion.site/Syncs-67be5281858f414da27b469043a21a0d

Issue:
sync block doesn't take full width of the page content. Causes certain blocks like divider to be squished.

Before:
![image](https://user-images.githubusercontent.com/21371266/130011998-d71be1e0-3803-4672-aedc-fcad2c3ada54.png)


After:
![image](https://user-images.githubusercontent.com/21371266/130012228-373a6bcc-f390-4a28-8b95-80649ede719a.png)

renamed the sync-block class to notion-sync-block to be more consistent.