### PR TITLE
Callout inline and link issues

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -945,7 +945,6 @@ svg.notion-page-icon {
 
 .notion-callout {
   padding: 16px 16px 16px 12px;
-  display: inline-flex;
   width: 100%;
   border-radius: 3px;
   border-width: 1px;

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1879,6 +1879,11 @@ svg.notion-page-icon {
   font-weight: 500;
 }
 
+/* removes double underline with links */
+.notion-link .notion-page-title-text {
+  border-bottom: 0px;
+}
+
 .notion-collection-row {
   width: 100%;
   padding: 4px 0 8px;

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -945,6 +945,7 @@ svg.notion-page-icon {
 
 .notion-callout {
   padding: 16px 16px 16px 12px;
+  display: inline-flex;
   width: 100%;
   border-radius: 3px;
   border-width: 1px;
@@ -970,9 +971,7 @@ svg.notion-page-icon {
   margin-left: 8px;
   white-space: pre-wrap;
   word-break: break-word;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
+  width: 100%;
 }
 
 .notion-toggle {


### PR DESCRIPTION
Two issues in this PR.
1. blocks in callouts show links on new lines and don't take up the full width.
2. page mentions have 2 underlines because its a link as well as a page

page to test: https://potionsite.notion.site/Callout-9465a22dc9734fc1a9182d9f179b47fa

Before
![Screen Shot 2021-08-20 at 11 17 37 AM](https://user-images.githubusercontent.com/21371266/130277510-0bfec48a-16dd-48eb-9fcd-6a744ef7a53d.png)

After
![Screen Shot 2021-08-20 at 11 15 48 AM](https://user-images.githubusercontent.com/21371266/130277525-ee9a7677-e86f-4cf3-acf3-9b36d9d20b9f.png)
