### PR TITLE
Fix block being null in collections

### DIFF
--- a/packages/react-notion-x/src/components/collection-view-list.tsx
+++ b/packages/react-notion-x/src/components/collection-view-list.tsx
@@ -19,6 +19,7 @@ export const CollectionViewList: React.FC<CollectionViewProps> = ({
         <div className='notion-list-body'>
           {collectionData.blockIds.map((blockId) => {
             const block = recordMap.block[blockId]?.value as PageBlock
+            if(!block) return null
 
             const titleSchema = collection.schema.title
             const titleData = block?.properties?.title


### PR DESCRIPTION
id to test where this usecase happens: 6acb5043abcf4966a47244b03ca61a88

The block in collections could be null causing errors in the collection. just throwing out the row if we don't have the data.
