### PR TITLE
Fix image caption and make images with url captions a link

### DIFF
--- a/packages/react-notion-x/src/components/asset-wrapper.tsx
+++ b/packages/react-notion-x/src/components/asset-wrapper.tsx
@@ -3,29 +3,73 @@ import { BaseContentBlock, Block } from 'notion-types'
 import { Asset } from './asset'
 import { cs } from '../utils'
 import { Text } from './text'
+import { useNotionContext } from '..'
+import { parsePageId } from 'notion-utils'
 
 export const AssetWrapper: React.FC<{
   blockId: string
   block: Block
 }> = ({ blockId, block }) => {
   const value = block as BaseContentBlock
+  const { components, mapPageUrl } = useNotionContext()
+
+  let isURL = false
+  if(value?.properties?.caption?.length > 0) {
+    const caption: string = value?.properties?.caption[0][0]
+    const id = parsePageId(caption, { uuid: true })
+
+    const isPage = caption.charAt(0) === '/' && id
+    if(block.type == 'image' && validURL(caption) || isPage) {
+      isURL = true
+    }
+  }
+
+  const figure = <figure
+                    className={cs(
+                      'notion-asset-wrapper',
+                      `notion-asset-wrapper-${block.type}`,
+                      value.format?.block_full_width && 'notion-asset-wrapper-full',
+                      blockId
+                    )}
+                  >
+                    <Asset block={value}>
+                      {value?.properties?.caption && !isURL && (
+                        <figcaption className='notion-asset-caption'>
+                          <Text value={value.properties.caption} block={block} />
+                        </figcaption>
+                      )}
+                    </Asset>
+                  </figure>
+
+
+  //allows for an image to be a link
+  if(isURL) {
+    const caption: string = value?.properties?.caption[0][0]
+    const id = parsePageId(caption, { uuid: true })
+    const isPage = caption.charAt(0) === '/' && id
+    return (
+      <components.pageLink
+        style={{width: '100%'}}
+        href={isPage? mapPageUrl(id) : caption}
+      >
+        {figure}
+      </components.pageLink>
+    )
+  }
 
   return (
-    <figure
-      className={cs(
-        'notion-asset-wrapper',
-        `notion-asset-wrapper-${block.type}`,
-        value.format?.block_full_width && 'notion-asset-wrapper-full',
-        blockId
-      )}
-    >
-      <Asset block={value}>
-        {value?.properties?.caption && (
-          <figcaption className='notion-asset-caption'>
-            <Text value={block.properties.caption} block={block} />
-          </figcaption>
-        )}
-      </Asset>
-    </figure>
+    <>
+      {figure}
+    </>
   )
+}
+
+function validURL(str) {
+  var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+    '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+    '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+    '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+  return !!pattern.test(str);
 }

--- a/packages/react-notion-x/src/components/asset-wrapper.tsx
+++ b/packages/react-notion-x/src/components/asset-wrapper.tsx
@@ -19,13 +19,13 @@ export const AssetWrapper: React.FC<{
         blockId
       )}
     >
-      <Asset block={value} />
-
-      {value?.properties?.caption && (
-        <figcaption className='notion-asset-caption'>
-          <Text value={block.properties.caption} block={block} />
-        </figcaption>
-      )}
+      <Asset block={value}>
+        {value?.properties?.caption && (
+          <figcaption className='notion-asset-caption'>
+            <Text value={block.properties.caption} block={block} />
+          </figcaption>
+        )}
+      </Asset>
     </figure>
   )
 }

--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -222,7 +222,7 @@ export const Asset: React.FC<{
         src={src}
         alt={alt}
         style={assetStyle}
-        zoomable={true}
+        zoomable={false}
         height={style.height as number}
       />
     )

--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -23,8 +23,9 @@ const types = [
 ]
 
 export const Asset: React.FC<{
-  block: BaseContentBlock
-}> = ({ block }) => {
+  block: BaseContentBlock,
+  children: any
+}> = ({ block, children }) => {
   const { recordMap, mapImageUrl, components } = useNotionContext()
 
   if (!block || !types.includes(block.type)) {
@@ -37,7 +38,8 @@ export const Asset: React.FC<{
     justifyContent: 'center',
     alignSelf: 'center',
     width: '100%',
-    maxWidth: '100%'
+    maxWidth: '100%',
+    flexDirection: 'column'
   }
 
   const assetStyle: React.CSSProperties = {}
@@ -226,5 +228,8 @@ export const Asset: React.FC<{
     )
   }
 
-  return <div style={style}>{content}</div>
+  return <div style={style}>
+          {content}
+          {children}
+        </div>
 }


### PR DESCRIPTION
Testin on: 3492bd6dbaf44fe7a5cac62c5d402f06

Made captions aligned with images. Before they were right aligned even when the image is centered
![image](https://user-images.githubusercontent.com/21371266/133860366-5d520543-6795-4188-abbf-6a38f1104cee.png)

Made images like this one clickable with a link.
To do this set the caption to be just a valid url or a notion page id.
like https://google.com or /3492bd6dbaf44fe7a5cac62c5d402f06
![image](https://user-images.githubusercontent.com/21371266/133860382-3fe4ab90-86e9-4cea-b200-6ece681ad0b6.png)



