### PR TITLE
style: :art: change position in .notion-viewport to relative

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -231,7 +231,7 @@
 }
 
 .notion-viewport {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Related to this issue [https://github.com/NotionX/react-notion-x/issues/135](https://github.com/NotionX/react-notion-x/issues/135). 

Found that in the class `notion-viewport` there's a CSS position `position: fixed` and that makes the overlay on the page that makes the user cannot interact with the page.
