### PR TITLE
fixed the database filters not being added

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -262,6 +262,7 @@ export class NotionAPI {
     collectionViewId: string,
     {
       type = 'table',
+      query,
       groups = undefined,
       limit = 999999,
       searchQuery = '',
@@ -304,6 +305,7 @@ export class NotionAPI {
           }
         }
       },
+      ...query, //add the filters
       searchQuery,
       userTimeZone
     }


### PR DESCRIPTION
With the changes to the querycollections api the filters weren't added on. This fixes that.
