### PR TITLE
open up same domain links in the same tab

### DIFF
--- a/example/pages/[pageId].tsx
+++ b/example/pages/[pageId].tsx
@@ -71,6 +71,7 @@ export default function NotionPage({ recordMap }) {
       <NotionRenderer recordMap={recordMap}
                       fullPage={true}
                       darkMode={false}
+                      rootDomain='localhost:9090' // used to detect root domain links and open this in the same tab
                       components={{
                         collection: Collection,
                         collectionRow: CollectionRow

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -23,7 +23,7 @@ export const Text: React.FC<{
   linkProtocol?: string
   inline?: boolean // TODO: currently unused
 }> = ({ value, block, linkProps, linkProtocol }) => {
-  const { components, recordMap, mapPageUrl, mapImageUrl } = useNotionContext()
+  const { components, recordMap, mapPageUrl, mapImageUrl, rootDomain } = useNotionContext()
 
   return (
     <React.Fragment>
@@ -143,13 +143,13 @@ export const Text: React.FC<{
               const pathname = v.substr(1)
               const id = parsePageId(pathname, { uuid: true })
 
-              if (v[0] === '/' && id) {
+              if ((v[0] === '/' || v.includes(rootDomain)) && id) {
                 // console.log('a', id)
 
                 return (
                   <components.pageLink
                     className='notion-link'
-                    href={mapPageUrl(id)}
+                    href={v.includes(rootDomain) ? v : mapPageUrl(id)}
                     {...linkProps}
                   >
                     {element}

--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -19,6 +19,7 @@ export interface NotionContext {
   searchNotion?: SearchNotion
 
   rootPageId?: string
+  rootDomain?: string
 
   fullPage: boolean
   darkMode: boolean
@@ -43,6 +44,7 @@ export interface PartialNotionContext {
   searchNotion?: SearchNotion
 
   rootPageId?: string
+  rootDomain?: string
 
   fullPage?: boolean
   darkMode?: boolean

--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -20,6 +20,7 @@ export interface NotionRendererProps {
   searchNotion?: SearchNotion
 
   rootPageId?: string
+  rootDomain?: string
   fullPage?: boolean
   darkMode?: boolean
   previewImages?: boolean
@@ -64,6 +65,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
   searchNotion,
   fullPage,
   rootPageId,
+  rootDomain,
   darkMode,
   previewImages,
   showCollectionViewDropdown,
@@ -91,6 +93,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
       searchNotion={searchNotion}
       fullPage={fullPage}
       rootPageId={rootPageId}
+      rootDomain={rootDomain}
       darkMode={darkMode}
       previewImages={previewImages}
       showCollectionViewDropdown={showCollectionViewDropdown}


### PR DESCRIPTION
Added a prop to NotionRenderer that allows you to set the rootDomain for your site. With this set any links to that domain will open up in the same tab instead of opening it up in another tab (how it worked previously).
