### PR TITLE
Add addSignedUrls method

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -191,10 +191,14 @@ export class NotionAPI {
     gotOptions = {}
   }: {
     recordMap: notion.ExtendedRecordMap
-    contentBlockIds: string[]
+    contentBlockIds?: string[]
     gotOptions?: OptionsOfJSONResponseBody
   }) {
     recordMap.signed_urls = {}
+
+    if (!contentBlockIds) {
+      contentBlockIds = getPageContentBlockIds(recordMap)
+    }
 
     const allFileInstances = contentBlockIds.flatMap((blockId) => {
       const block = recordMap.block[blockId].value


### PR DESCRIPTION
Refactored the logic to add signed urls to record map in a separate method, this allows you to sign urls on an existing record map

This is useful because signed urls expire after a few days and if you store the record map in a database you need to refresh them before serving them to the user