### PR TITLE
Draft: text: don't loose # out of internal links

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -84,9 +84,10 @@ export const Block: React.FC<BlockProps> = (props) => {
     ;(block as any).type = 'collection_view_page'
   }
 
-  const blockId = hideBlockId
+  const idString = uuidToId(block.id);
+  const blockClass = hideBlockId
     ? 'notion-block'
-    : `notion-block-${uuidToId(block.id)}`
+    : `notion-block-${idString}`
 
   switch (block.type) {
     case 'collection_view_page':
@@ -179,9 +180,10 @@ export const Block: React.FC<BlockProps> = (props) => {
                 'notion',
                 'notion-app',
                 darkMode ? 'dark-mode' : 'light-mode',
-                blockId,
+                blockClass,
                 className
               )}
+              id={hideBlockId ? idString : undefined}
             >
               <div className='notion-viewport' />
 

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -144,12 +144,13 @@ export const Text: React.FC<{
               const id = parsePageId(pathname, { uuid: true })
 
               if ((v[0] === '/' || v.includes(rootDomain)) && id) {
-                // console.log('a', id)
-
+                const href = v.includes(rootDomain) 
+                  ? v 
+                  : `${mapPageUrl(id)}${v.includes('#') ? v.replace(/^.+(#.+)$/, '$2') : ''}`;
                 return (
                   <components.pageLink
                     className='notion-link'
-                    href={v.includes(rootDomain) ? v : mapPageUrl(id)}
+                    href={href}
                     {...linkProps}
                   >
                     {element}

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -146,7 +146,7 @@ export const Text: React.FC<{
               if ((v[0] === '/' || v.includes(rootDomain)) && id) {
                 const href = v.includes(rootDomain) 
                   ? v 
-                  : `${mapPageUrl(id)}${v.includes('#') ? v.replace(/^.+(#.+)$/, '$2') : ''}`;
+                  : `${mapPageUrl(id)}${v.includes('#') ? v.replace(/^.+(#.+)$/, '$1') : ''}`;
                 return (
                   <components.pageLink
                     className='notion-link'


### PR DESCRIPTION
I frequently use # to blocks in internal links. For example, I make own more compact TOCs, or navigation links in text, so I help reader to jump another place on page quickly

currently, hash part of links is loosing and all that links become useless

### examples
Page with custom TOC w/ hot hash links:
https://www.notion.so/ru-tesla/Tesla-Model-3-26bd09a54f6e4214a52335caf315118d

Same page with useless links:
https://tesla-wiki.vercel.app/m3