### PR TITLE
fix: NotionAPI collectionQuery error Cannot read property 'type' of…

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -122,7 +122,7 @@ export class NotionAPI {
                 type: collectionView?.type,
                 query: this.getQuery(collectionView),
                 groups:
-                  collectionView.type === 'board'
+                  collectionView?.type === 'board'
                     ? collectionView?.format?.board_groups2 ||
                       (collectionView?.format as any)?.board_groups ||
                       collectionView?.format?.board_columns


### PR DESCRIPTION
Have the same error like https://github.com/NotionX/react-notion-x/issues/147 and found out that this `?` is crusial