### PR TITLE
notion-client - return signed URL for page headers

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -209,9 +209,10 @@ export class NotionAPI {
           block.type === 'audio' ||
           (block.type === 'image' && block.file_ids?.length) ||
           block.type === 'video' ||
-          block.type === 'file')
+          block.type === 'file' ||
+          block.type === 'page')
       ) {
-        const source = block.properties?.source?.[0]?.[0]
+        const source = block.type === 'page' ? block.format?.page_cover : block.properties?.source?.[0]?.[0]
         // console.log(block, source)
 
         if (source) {


### PR DESCRIPTION

This is a fix for [#163](https://github.com/NotionX/react-notion-x/issues/163)