### PR TITLE
Made it so captions on embeds can be seen

### DIFF
--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -229,9 +229,12 @@ export const Asset: React.FC<{
   }
 
   return (
-    <div style={style}>
-      {content}
-      {children}
-    </div>
+    <>
+      <div style={style}>
+        {content}
+        {block.type === 'image' && children}
+      </div>
+      {block.type !== 'image' && children}
+    </>
   )
 }


### PR DESCRIPTION
There was a bug where no captions could be seen except for images.
Embed captions were hidden by the embed.

So I moved captions outside of the asset block for embeds. The images caption needs to stay inside the asset so it can have the correct styling when an image is centered.

PageId to test: 5d4e290ca4604d8fb809af806a6c1749

Fixed image example
![Screen Shot 2021-12-03 at 2 08 03 PM](https://user-images.githubusercontent.com/21371266/144679707-d631473a-34fe-4397-add9-e4da8a070813.png)

Fixed embed example
![Screen Shot 2021-12-03 at 2 07 42 PM](https://user-images.githubusercontent.com/21371266/144679719-5a2a83a4-20bf-4f3d-bd34-f2fa093e7c60.png)

