### PR TITLE
Navigation header contents props

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -34,6 +34,7 @@ interface BlockProps {
 
   footer?: React.ReactNode
   pageHeader?: React.ReactNode
+  navigationHeader?: React.ReactNode
   pageFooter?: React.ReactNode
   pageAside?: React.ReactNode
   pageCover?: React.ReactNode
@@ -68,6 +69,7 @@ export const Block: React.FC<BlockProps> = (props) => {
     bodyClassName,
     footer,
     pageHeader,
+    navigationHeader,
     pageFooter,
     pageAside,
     pageCover,
@@ -189,7 +191,7 @@ export const Block: React.FC<BlockProps> = (props) => {
               <div className='notion-viewport' />
 
               <div className='notion-frame'>
-                <PageHeader />
+                <PageHeader navigationHeader={navigationHeader} />
 
                 <div className='notion-page-scroller'>
                   {hasPageCover ? (
@@ -230,7 +232,7 @@ export const Block: React.FC<BlockProps> = (props) => {
                         <PageIcon block={block} defaultIcon={defaultPageIcon} />
                       </div>
                     )}
-
+                    
                     {pageHeader}
 
                     <h1 className='notion-title'>

--- a/packages/react-notion-x/src/components/page-header.tsx
+++ b/packages/react-notion-x/src/components/page-header.tsx
@@ -8,9 +8,14 @@ import { SearchIcon } from '../icons/search-icon'
 import { cs } from '../utils'
 import { SearchDialog } from './search-dialog'
 
-export const PageHeader: React.FC<{}> = () => {
+interface PageHeaderProps {
+  navigationHeader?: React.ReactNode
+}
+
+export const PageHeader: React.FC<PageHeaderProps> = (props) => {
   const { components, recordMap, rootPageId, mapPageUrl, searchNotion } =
     useNotionContext()
+  const { navigationHeader } = props
 
   const blockMap = recordMap.block
   const blockIds = Object.keys(blockMap)
@@ -127,6 +132,7 @@ export const PageHeader: React.FC<{}> = () => {
         </div>
 
         <div className='rhs'>
+          {navigationHeader}
           {hasSearch && (
             <div
               role='button'

--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -38,6 +38,7 @@ export interface NotionRendererProps {
 
   footer?: React.ReactNode
   pageHeader?: React.ReactNode
+  navigationHeader?: React.ReactNode
   pageFooter?: React.ReactNode
   pageAside?: React.ReactNode
   pageCover?: React.ReactNode


### PR DESCRIPTION
Hi! I'm very excited about react-notion-x and creating my site with it.

While react-notion-x is very good but I couldn't find a way to add the content on the navigation header.
So, I created the PR to realize it.

With this PR, you will be able to add some contents with the example code below:
```
<NotionRenderer
navigationHeader={
          <>
            <Link href='/fd1dded8884641ac85542cd5f65694da'>
              <span className='nav-link'>実績</span>
            </Link>
            <Link href='/78b7b0b82de343779c6d2cd00f0e16e6'>
            <span className='nav-link'>当社について</span>
            </Link>
          </>
}
/>
```

I hope this PR helps.

![image](https://user-images.githubusercontent.com/56193/144751461-a1f4d1c9-bf00-464c-997e-4dcdf32d4886.png)
