### PR TITLE
fix: align left for table of content

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -181,7 +181,6 @@
 .notion-aside-table-of-contents {
   display: flex;
   flex-direction: column;
-  align-items: center;
   max-height: calc(100vh - 148px - 16px);
   overflow: hidden auto;
   min-width: 222px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6268441/145056777-82afe4d2-cd26-4508-beac-d727a1aa3386.png)
This PR fix the styling above. 
Feel free to close this directly if you think the original one is better.