### PR TITLE
fixed uncategorized issue for board views

### DIFF
--- a/packages/react-notion-x/src/components/collection-view-board.tsx
+++ b/packages/react-notion-x/src/components/collection-view-board.tsx
@@ -119,7 +119,7 @@ function Board({ collectionView, collectionData, collection, padding }) {
 
             const schema = collection.schema[p.property]
             const group = (collectionData as any)[
-              `results:select:${p?.value?.value || ' uncategorized'}`
+              `results:select:${p?.value?.value || 'uncategorized'}`
             ]
 
             if (!group || !schema || p.hidden) {


### PR DESCRIPTION
Fixed board view not having all of the cards after adding groupedBy for tables.

pageId: dd5d904fb13d402cbba6d6bdfecfa181