### PR TITLE
added the block for page links

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -37,6 +37,7 @@ export type BlockType =
   | 'collection_view_page'
   | 'transclusion_container'
   | 'transclusion_reference'
+  | 'alias'
   // fallback for unknown blocks
   | string
 
@@ -78,6 +79,7 @@ export type Block =
   | CollectionViewPageBlock
   | SyncBlock
   | SyncPointerBlock
+  | PageLink
 
 /**
  * Base properties shared by all blocks.
@@ -370,6 +372,15 @@ export interface SyncPointerBlock extends BaseBlock {
     transclusion_reference_pointer: {
       id: string
       spaceId: string
+    }
+  }
+}
+
+export interface PageLink extends BaseBlock {
+  type: 'alias'
+  format: {
+    alias_pointer: {
+      id: string
     }
   }
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -815,6 +815,23 @@ export const Block: React.FC<BlockProps> = (props) => {
     case 'transclusion_reference':
       return <SyncPointerBlock block={block} level={level + 1} {...props} />
 
+    case 'alias':
+      let blockPointerId = block?.format?.alias_pointer?.id
+      const linkedBlock = recordMap.block[blockPointerId]?.value
+      if (!linkedBlock) {
+        console.log('"p" missing block', blockPointerId)
+        return null
+      }
+
+      return (
+        <components.pageLink
+          className={cs('notion-page-link', blockPointerId)}
+          href={mapPageUrl(blockPointerId)}
+        >
+          <PageTitle block={linkedBlock} />
+        </components.pageLink>
+      )
+
     default:
       if (process.env.NODE_ENV !== 'production') {
         console.log(

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -816,7 +816,7 @@ export const Block: React.FC<BlockProps> = (props) => {
       return <SyncPointerBlock block={block} level={level + 1} {...props} />
 
     case 'alias':
-      let blockPointerId = block?.format?.alias_pointer?.id
+      const blockPointerId = block?.format?.alias_pointer?.id
       const linkedBlock = recordMap.block[blockPointerId]?.value
       if (!linkedBlock) {
         console.log('"p" missing block', blockPointerId)


### PR DESCRIPTION

Only allows you to link to pages that are in the same workspace.
Previously we had supported page links though the page mention block and text block page links.
This PR actually supports the Notion Page Link block as well.

Example of page link block here: 52353862df0f48ba85648db7d0acd1dd

![image](https://user-images.githubusercontent.com/21371266/149231198-501f3d4b-d397-4331-b1c3-4af54f39be75.png)

