### PR TITLE
Add support for simple table

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -38,6 +38,8 @@ export type BlockType =
   | 'transclusion_container'
   | 'transclusion_reference'
   | 'alias'
+  | 'table'
+  | 'table_row'
   // fallback for unknown blocks
   | string
 
@@ -80,6 +82,8 @@ export type Block =
   | SyncBlock
   | SyncPointerBlock
   | PageLink
+  | TableBlock
+  | TableRowBlock
 
 /**
  * Base properties shared by all blocks.
@@ -382,5 +386,30 @@ export interface PageLink extends BaseBlock {
     alias_pointer: {
       id: string
     }
+  }
+}
+
+export interface TableBlock extends BaseBlock {
+  type: 'table'
+  collection_id: ID
+  format: {
+    collection_pointer: {
+      id: ID
+      table: string
+      spaceId: ID
+    }
+    table_block_column_format: {
+      [column: string]: { width: number; color?: Color }
+    }
+    table_block_column_header: boolean
+    table_block_column_order: string[]
+  }
+  view_ids: ID[]
+}
+
+export interface TableRowBlock extends BaseBlock {
+  type: 'table_row'
+  properties: {
+    [column: string]: Decoration[]
   }
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -832,6 +832,32 @@ export const Block: React.FC<BlockProps> = (props) => {
         </components.pageLink>
       )
 
+    case 'table':
+      return (
+        <table className='notion-simple-table'>
+          <tbody>{children}</tbody>
+        </table>
+      )
+    case 'table_row':
+      const tableBlock = recordMap.block[block.parent_id]
+        .value as types.TableBlock
+      const order = tableBlock.format.table_block_column_order
+      const formatMap = tableBlock.format.table_block_column_format
+
+      return (
+        <tr className='notion-simple-table-row'>
+          {order.map((column) => {
+            return (
+              <td key={column} style={{ width: formatMap[column].width }}>
+                <div className='notion-simple-table-cell'>
+                  {block.properties[column]}
+                </div>
+              </td>
+            )
+          })}
+        </tr>
+      )
+
     default:
       if (process.env.NODE_ENV !== 'production') {
         console.log(

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -834,7 +834,7 @@ export const Block: React.FC<BlockProps> = (props) => {
 
     case 'table':
       return (
-        <table className='notion-simple-table'>
+        <table className={cs('notion-simple-table', blockId)}>
           <tbody>{children}</tbody>
         </table>
       )
@@ -845,7 +845,7 @@ export const Block: React.FC<BlockProps> = (props) => {
       const formatMap = tableBlock.format.table_block_column_format
 
       return (
-        <tr className='notion-simple-table-row'>
+        <tr className={cs('notion-simple-table-row', blockId)}>
           {order.map((column) => {
             const color = formatMap[column].color
             return (

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -847,8 +847,13 @@ export const Block: React.FC<BlockProps> = (props) => {
       return (
         <tr className='notion-simple-table-row'>
           {order.map((column) => {
+            const color = formatMap[column].color
             return (
-              <td key={column} style={{ width: formatMap[column].width }}>
+              <td
+                key={column}
+                className={color ? `notion-${color}` : ''}
+                style={{ width: formatMap[column].width }}
+              >
                 <div className='notion-simple-table-cell'>
                   {block.properties[column]}
                 </div>

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2391,3 +2391,19 @@ svg.notion-page-icon {
   display: inline-flex;
   align-items: center;
 }
+
+.notion-simple-table {
+  border: 1px solid var(--fg-color-5);
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 14px;
+}
+
+.notion-simple-table tr:first-child td {
+  background: var(--bg-color-0);
+}
+
+.notion-simple-table td {
+  border: 1px solid var(--fg-color-5);
+  padding: 8px 8px;
+}


### PR DESCRIPTION
inspired by #166 

add block type and also add some simple stylesheet

![simple-table](https://user-images.githubusercontent.com/29378026/149625047-ace05203-4193-4694-883a-383b52ee1d0e.png)

***
also noticed default css variable is not variety enough just like `fg-color-1(~5)`
