### PR TITLE
fix: Prop className did not match of Code component

### DIFF
--- a/packages/react-notion-x/src/components/code.tsx
+++ b/packages/react-notion-x/src/components/code.tsx
@@ -11,7 +11,7 @@ export const Code: React.FC<{ code: string; language: string }> = ({
   const prismLanguage = languages[languageL] || languages.javascript
 
   return (
-    <pre className='notion-code'>
+    <pre className={`notion-code language-${languageL}`}>
       <code
         className={`language-${languageL}`}
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
This PR fix the issue: #62 

[the \<pre\> will automatically get the language-xxxx class (if it doesn’t already have it) and will be styled as a code block.](https://prismjs.com/#:~:text=the%20%3Cpre%3E%20will%20automatically%20get%20the%20language%2Dxxxx%20class%20(if%20it%20doesn%E2%80%99t%20already%20have%20it)%20and%20will%20be%20styled%20as%20a%20code%20block.)

