### PR TITLE
fix: notion simple table when there are empty cells

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -861,7 +861,7 @@ export const Block: React.FC<BlockProps> = (props) => {
                 }}
               >
                 <div className='notion-simple-table-cell'>
-                  <Text value={block.properties[column]} block={block} />
+                  <Text value={block.properties ? block.properties[column] : [['ㅤ']]} block={block} />
                 </div>
               </td>
             )


### PR DESCRIPTION
Simple Table is not working when there are empty cells in the table. 