### PR TITLE
add non-text support for getpageProperty 

### DIFF
--- a/packages/notion-types/src/core.ts
+++ b/packages/notion-types/src/core.ts
@@ -87,10 +87,13 @@ export type ExternalLinkFormat = ['‣', [string, string]]
 export type DateFormat = ['d', FormattedDate]
 
 export interface FormattedDate {
-  type: 'date' | 'daterange'
+  type: 'date' | 'daterange' | 'datetime' | 'datetimerange'
   start_date: string
+  start_time?: string
   end_date?: string
+  end_time?: string
   date_format?: string
+  time_zone?: string
 }
 
 export type SubDecoration =

--- a/packages/notion-utils/src/get-page-property.ts
+++ b/packages/notion-utils/src/get-page-property.ts
@@ -1,19 +1,26 @@
-import { Block, ExtendedRecordMap } from 'notion-types'
+import { Block, DateFormat, ExtendedRecordMap } from 'notion-types'
 import { getTextContent } from './get-text-content'
 
 /**
  * Gets the value of a collection property for a given page (collection item).
  *
- * TODO: handle non-text property types.
+ * @param propertyName property name
+ * @param block Page block, often be first block in blockMap
+ * @param recordMap
+ * @returns - The return value types will follow the following principles:
+ *  1. if property is date type, it will return `number` or `number[]`(depends on `End Date` switch)
+ *  2. property is text-like will return `string`
+ *  3. multi select property will return `string[]`
+ *  4. checkbox property return `boolean`
+ * @todo complete all no-text property type
  */
 export function getPageProperty(
   propertyName: string,
   block: Block,
   recordMap: ExtendedRecordMap
-): string | null {
-  if (!block.properties) {
-    // TODO: check parent page?
-    return null
+) {
+  if (!block.properties || !Object.keys(recordMap.collection)) {
+    throw new Error(`this block ${block.id} has not properties or this recordMap has no collection record`)
   }
 
   const collection = recordMap.collection[block.parent_id]?.value
@@ -23,8 +30,39 @@ export function getPageProperty(
       (key) => collection.schema[key]?.name === propertyName
     )
 
-    if (propertyId) {
-      return getTextContent(block.properties[propertyId])
+    const { type } = collection.schema[propertyId]
+    const content = getTextContent(block.properties[propertyId])
+
+    switch (type) {
+      case 'created_time':
+        return block.created_time
+      case 'multi_select':
+        return content.split(',')
+      case 'date':
+        const property = block.properties[propertyId] as [['‣', [DateFormat]]]
+        const formatDate = property[0][1][0][1]
+        if (formatDate.type == 'datetime') {
+          return new Date(
+            `${formatDate.start_date} ${formatDate.start_time}`
+          ).getTime()
+        } else if (formatDate.type == 'date') {
+          return new Date(formatDate.start_date).getTime()
+        } else if (formatDate.type == 'datetimerange') {
+          const { start_date, start_time, end_date, end_time } = formatDate
+          const startTime = new Date(`${start_date} ${start_time}`).getTime()
+          const endTime = new Date(`${end_date} ${end_time}`).getTime()
+          return [startTime, endTime]
+        } else {
+          const startTime = new Date(formatDate.start_date).getTime()
+          const endTime = new Date(formatDate.end_date).getTime()
+          return [startTime, endTime]
+        }
+      case 'checkbox':
+        return content == 'Yes'
+      case 'last_edited_time':
+        return block.last_edited_time
+      default:
+        return content
     }
   }
 

--- a/packages/notion-utils/src/get-page-property.ts
+++ b/packages/notion-utils/src/get-page-property.ts
@@ -14,6 +14,9 @@ import { getTextContent } from './get-text-content'
  *  4. checkbox property return `boolean`
  * @todo complete all no-text property type
  */
+export function getPageProperty<
+  T = string | number | boolean | string[] | number[]
+>(propertyName: string, block: Block, recordMap: ExtendedRecordMap): T
 export function getPageProperty(
   propertyName: string,
   block: Block,


### PR DESCRIPTION
support which marked with TODO 😁

Actually, the param `block` is not much useful (maybe `pageId`  which was `block.parent_id` would better), reserve it for non-breaking changes

***
also done an unit test later, but few of wrong type definitions which need be fix prevent me from using my test cases