### PR TITLE
fix: notion table filters when grouping is also applied

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -390,6 +390,7 @@ export class NotionAPI {
           [reducerLabel]: {
             type: 'groups',
             groupBy,
+            ...(collectionView?.query2?.filter && {filter: collectionView?.query2?.filter}),
             groupSortPreference: groups.map((group) => group?.value),
             limit
           },


### PR DESCRIPTION
```
Before all: Sorry I can't share the page as it's my working draft.
```

# Problem

![image](https://user-images.githubusercontent.com/5344431/151352120-52b73db9-37fb-4556-b505-fb72401c912a.png)

When grouping and sorting are both aplied on a table, seems that `getCollectionData` won't apply the filter.

# Investigation

I compared official website's API query:
```
{
    "collection": {
        "id": "70e01f9c-dbd3-46b6-8efc-df9ebb589b96",
        "spaceId": "c8569e32-89f8-4ddf-ac21-adb5a19fdb24"
    },
    "collectionView": {
        "id": "36a64343-6578-4e81-81a7-5e9355b769a9",
        "spaceId": "c8569e32-89f8-4ddf-ac21-adb5a19fdb24"
    },
    "loader": {
        "type": "reducer",
        "reducers": {
            "table_groups": {
                "type": "groups",
                "groupBy": {
                    "sort": {
                        "type": "manual"
                    },
                    "type": "multi_select",
                    "property": "_gbq",
                    "hideEmptyGroups": true
                },
                "filter": {
                    "filters": [
                        {
                            "filter": {
                                "value": {
                                    "type": "exact",
                                    "value": true
                                },
                                "operator": "checkbox_is"
                            },
                            "property": "fK<{"
                        }
                    ],
                    "operator": "and"
                },
                "groupSortPreference": [
                    {
                        "type": "multi_select",
                        "value": "In Progress"
                    },
                    {
                        "type": "multi_select",
                        "value": "Need Repair"
                    },
                    {
                        "type": "multi_select",
                        "value": "Maintaining"
                    },
                    {
                        "type": "multi_select",
                        "value": "Monitoring"
                    },
                    {
                        "type": "multi_select",
                        "value": "Finalized"
                    },
                    {
                        "type": "multi_select",
                        "value": "Abandon"
                    },
                    {
                        "type": "multi_select",
                        "value": "Accumulative"
                    },
                    {
                        "type": "multi_select",
                        "value": "Give Up"
                    },
                    {
                        "type": "multi_select"
                    }
                ],
                "limit": 12
            },
            ...
        },
        "filter": {
            "filters": [
                {
                    "filter": {
                        "value": {
                            "type": "exact",
                            "value": true
                        },
                        "operator": "checkbox_is"
                    },
                    "property": "fK<{"
                }
            ],
            "operator": "and"
        },
        "sort": [
            {
                "property": "_gbq",
                "direction": "ascending"
            },
            {
                "property": "n}X^",
                "direction": "descending"
            },
            {
                "property": "6664b1e0-80cd-4149-ac54-3f494938306d",
                "direction": "ascending"
            },
            {
                "property": "eEdv",
                "direction": "descending"
            }
        ],
        "searchQuery": "",
        "userTimeZone": "Asia/Shanghai"
    }
}
```

And  ours:
```
{
    "collection": {
        "id": "70e01f9c-dbd3-46b6-8efc-df9ebb589b96"
    },
    "collectionView": {
        "id": "36a64343-6578-4e81-81a7-5e9355b769a9"
    },
    "loader": {
        "type": "reducer",
        "reducers": {
            "table_groups": {
                "type": "groups",
                "groupBy": {
                    "sort": {
                        "type": "manual"
                    },
                    "type": "multi_select",
                    "property": "_gbq",
                    "hideEmptyGroups": true
                },
                "groupSortPreference": [
                    {
                        "type": "multi_select",
                        "value": "In Progress"
                    },
                    {
                        "type": "multi_select",
                        "value": "Need Repair"
                    },
                    {
                        "type": "multi_select",
                        "value": "Maintaining"
                    },
                    {
                        "type": "multi_select",
                        "value": "Monitoring"
                    },
                    {
                        "type": "multi_select",
                        "value": "Finalized"
                    },
                    {
                        "type": "multi_select",
                        "value": "Abandon"
                    },
                    {
                        "type": "multi_select",
                        "value": "Accumulative"
                    },
                    {
                        "type": "multi_select",
                        "value": "Give Up"
                    },
                    {
                        "type": "multi_select"
                    }
                ],
                "limit": 9999
            },
            ...
        },
        "sort": [
            {
                "property": "_gbq",
                "direction": "ascending"
            },
            {
                "property": "n}X^",
                "direction": "descending"
            },
            {
                "property": "6664b1e0-80cd-4149-ac54-3f494938306d",
                "direction": "ascending"
            },
            {
                "property": "eEdv",
                "direction": "descending"
            }
        ],
        "filter": {
            "filters": [
                {
                    "filter": {
                        "value": {
                            "type": "exact",
                            "value": true
                        },
                        "operator": "checkbox_is"
                    },
                    "property": "fK<{"
                }
            ],
            "operator": "and"
        },
        "searchQuery": "",
        "userTimeZone": "America/New_York"
    }
}
```
(Same parts omited due to length)

Notice the loader.reducers.table_groups.filter, our request are missing it. And that's the reason according my debugging.

# Fix
I added this line, and then everythings goes fine.