### PR TITLE
Preserve fragment identifiers in links

### DIFF
--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -3,7 +3,7 @@ import { Block, Decoration } from 'notion-types'
 import { parsePageId } from 'notion-utils'
 
 import { useNotionContext } from '../context'
-import { formatDate } from '../utils'
+import { formatDate, getHashFragmentValue } from '../utils'
 import { Equation } from './equation'
 import { PageTitle } from './page-title'
 import { GracefulImage } from './graceful-image'
@@ -145,12 +145,14 @@ export const Text: React.FC<{
               const id = parsePageId(pathname, { uuid: true })
 
               if ((v[0] === '/' || v.includes(rootDomain)) && id) {
-                // console.log('a', id)
+                const href = v.includes(rootDomain)
+                  ? v
+                  : `${mapPageUrl(id)}${getHashFragmentValue(v)}`
 
                 return (
                   <components.pageLink
                     className='notion-link'
-                    href={v.includes(rootDomain) ? v : mapPageUrl(id)}
+                    href={href}
                     {...linkProps}
                   >
                     {element}

--- a/packages/react-notion-x/src/utils.ts
+++ b/packages/react-notion-x/src/utils.ts
@@ -93,6 +93,10 @@ export const defaultMapPageUrl = (rootPageId?: string) => (pageId: string) => {
   }
 }
 
+export const getHashFragmentValue = (url: string) => {
+  return url.includes('#') ? url.replace(/^.+(#.+)$/, '$1') : ''
+}
+
 const months = [
   'Jan',
   'Feb',


### PR DESCRIPTION
Changes to preserve the fragment identifiers in pageLinks. We use custom navigation links instead of notion's TOC in a lot of documents and this will help preserve that behaviour in notion-x.

The earlier PR (#150) looks abandoned. I've not attempted to add ids to all the blocks since the hash links that are automatically generated for headings are enough for our requirements.


---
Amazing work on the library btw. I'm frankly amazed this even exists. Thanks!