### PR TITLE
Optimizing images

### DIFF
--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -223,6 +223,7 @@ export const Asset: React.FC<{
         alt={alt}
         zoomable={false}
         height={style.height as number}
+        width={block?.format?.block_width}
         style={assetStyle}
       />
     )

--- a/packages/react-notion-x/src/components/lazy-image.tsx
+++ b/packages/react-notion-x/src/components/lazy-image.tsx
@@ -141,6 +141,7 @@ export const LazyImage: React.FC<{
           style={style}
           loading='lazy'
           decoding='async'
+          width={null}
           height={height || null}
           ref={attachZoomRef}
           onLoad={(e: any) => {

--- a/packages/react-notion-x/src/components/lazy-image.tsx
+++ b/packages/react-notion-x/src/components/lazy-image.tsx
@@ -12,8 +12,18 @@ export const LazyImage: React.FC<{
   className?: string
   style?: React.CSSProperties
   height?: number
+  width?: number
   zoomable?: boolean
-}> = ({ src, alt, className, style, zoomable = false, height, ...rest }) => {
+}> = ({
+  src,
+  alt,
+  className,
+  style,
+  zoomable = false,
+  height,
+  width,
+  ...rest
+}) => {
   const { recordMap, zoom, previewImages, customImages, components } =
     useNotionContext()
 
@@ -117,6 +127,10 @@ export const LazyImage: React.FC<{
     // TODO: GracefulImage doesn't seem to support refs, but we'd like to prevent
     // invalid images from loading as error states
 
+    if (width) {
+      src += `&width=${width}`
+    }
+
     // Render when customImages flag is enabled
     if (customImages) {
       return (
@@ -127,7 +141,6 @@ export const LazyImage: React.FC<{
           style={style}
           loading='lazy'
           decoding='async'
-          width={null}
           height={height || null}
           ref={attachZoomRef}
           onLoad={(e: any) => {


### PR DESCRIPTION
PageId: 3492bd6dbaf44fe7a5cac62c5d402f06

Using the block width to grab the correct image size and optimize images.

![image](https://user-images.githubusercontent.com/21371266/154364510-d262724d-02c9-48d5-801a-49ccc8c579ea.png)


