### PR TITLE
Show the checkbox text on collection card

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+@uduakabaci:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=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

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-x-example",
-  "version": "4.16.3",
+  "version": "4.16.4",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -14,10 +14,10 @@
   "dependencies": {
     "next": "^11.1.2",
     "notion-client": "^4.16.1",
-    "notion-utils": "^4.16.0",
+    "notion-utils": "^4.16.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-notion-x": "^4.16.3"
+    "react-notion-x": "^4.16.4"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^11.1.2",

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-x-example",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -17,7 +17,7 @@
     "notion-utils": "^4.16.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-notion-x": "^4.16.2"
+    "react-notion-x": "^4.16.3"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^11.1.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.16.3",
+  "version": "4.16.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,10 @@
   "packages": [
     "packages/*",
     "example/"
-  ]
+  ],
+  "command": {
+    "publish": {
+      "registry": "https://npm.pkg.github.com/uduakabaci"
+    }
+  }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.16.2",
+  "version": "4.16.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/notion-client/package.json
+++ b/packages/notion-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uduakabaci/notion-client",
-  "version": "4.16.1",
+  "version": "4.16.4",
   "description": "Robust TypeScript client for the unofficial Notion API.",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "got": "^11.8.1",
-    "notion-types": "^4.16.0",
-    "notion-utils": "^4.16.0",
+    "notion-types": "^4.16.4",
+    "notion-utils": "^4.16.4",
     "p-map": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/notion-client/package.json
+++ b/packages/notion-client/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "notion-client",
+  "name": "@uduakabaci/notion-client",
   "version": "4.16.1",
   "description": "Robust TypeScript client for the unofficial Notion API.",
-  "repository": "NotionX/react-notion-x",
-  "author": "Travis Fischer <travis@transitivebullsh.it>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uduakabaci/baby.git"
+  },
+  "author": "uduakabaci udofe <uduakbaciudofe@gmail.com>",
   "license": "MIT",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",

--- a/packages/notion-types/package.json
+++ b/packages/notion-types/package.json
@@ -2,8 +2,11 @@
   "name": "notion-types",
   "version": "4.16.0",
   "description": "TypeScript types for core Notion data structures.",
-  "repository": "NotionX/react-notion-x",
-  "author": "Travis Fischer <travis@transitivebullsh.it>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uduakabaci/baby.git"
+  },
+  "author": "uduakabaci udofe <uduakbaciudofe@gmail.com>",
   "license": "MIT",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",

--- a/packages/notion-types/package.json
+++ b/packages/notion-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-types",
-  "version": "4.16.0",
+  "version": "4.16.4",
   "description": "TypeScript types for core Notion data structures.",
   "repository": {
     "type": "git",

--- a/packages/notion-utils/package.json
+++ b/packages/notion-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-utils",
-  "version": "4.16.0",
+  "version": "4.16.4",
   "description": "Useful utilities for working with Notion data. Isomorphic.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "test": "ava -v 'build/cjs/**/*.test.js'"
   },
   "dependencies": {
-    "notion-types": "^4.16.0",
+    "notion-types": "^4.16.4",
     "p-queue": "6"
   },
   "devDependencies": {

--- a/packages/notion-utils/package.json
+++ b/packages/notion-utils/package.json
@@ -2,8 +2,11 @@
   "name": "notion-utils",
   "version": "4.16.0",
   "description": "Useful utilities for working with Notion data. Isomorphic.",
-  "repository": "NotionX/react-notion-x",
-  "author": "Travis Fischer <travis@transitivebullsh.it>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uduakabaci/baby.git"
+  },
+  "author": "uduakabaci udofe <uduakbaciudofe@gmail.com>",
   "license": "MIT",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",

--- a/packages/react-notion-x/package.json
+++ b/packages/react-notion-x/package.json
@@ -42,5 +42,6 @@
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16"
-  }
+  },
+  "gitHead": "7c9cb5e1faf6327c69f210c9c19920a8defa4ef9"
 }

--- a/packages/react-notion-x/package.json
+++ b/packages/react-notion-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-notion-x",
-  "version": "4.16.3",
+  "version": "4.16.4",
   "description": "Fast and accurate React renderer for Notion.",
   "repository": "NotionX/react-notion-x",
   "author": "Travis Fischer <travis@transitivebullsh.it>",
@@ -20,8 +20,8 @@
     "katex": "^0.13.18",
     "lodash.throttle": "^4.1.1",
     "medium-zoom": "^1.0.6",
-    "notion-types": "^4.16.0",
-    "notion-utils": "^4.16.0",
+    "notion-types": "^4.16.4",
+    "notion-utils": "^4.16.4",
     "prismjs": "^1.20.0",
     "rc-dropdown": "^3.1.2",
     "rc-menu": "^9.0.14",

--- a/packages/react-notion-x/package.json
+++ b/packages/react-notion-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-notion-x",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "description": "Fast and accurate React renderer for Notion.",
   "repository": "NotionX/react-notion-x",
   "author": "Travis Fischer <travis@transitivebullsh.it>",

--- a/packages/react-notion-x/src/components/property.tsx
+++ b/packages/react-notion-x/src/components/property.tsx
@@ -143,7 +143,9 @@ export const Property: React.FC<{
         case 'checkbox':
           const isChecked = data && data[0][0] === 'Yes'
 
-          return <Checkbox isChecked={isChecked} blockId={undefined} />
+          return <div className='notion-property-checkbox-container'>
+            <Checkbox isChecked={isChecked} blockId={undefined} />
+            <span className='notion-property-checkbox-text'>{schema.name}</span></div>
 
         case 'url':
           // TODO: refactor to less hackyh solution

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1247,6 +1247,19 @@ svg.notion-page-icon {
   max-height: 100%;
 }
 
+.notion-collection-card .notion-property-checkbox-container {
+  display: flex;
+}
+
+.notion-property-checkbox-text {
+  display: none;
+}
+
+.notion-collection-card .notion-property-checkbox-text {
+  display: inline-block;
+  margin-left: 6px;
+}
+
 .notion-property-checkbox {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
The library only shows a checkbox on a collection card without the checkbox's name. 
**This is what it looks like currently** 
![check-list-w-o-text](https://user-images.githubusercontent.com/18103407/155812329-91816487-a738-485a-8065-d1f57871174b.jpg)

**And this what it looks like on notion**
![check-list-w-text](https://user-images.githubusercontent.com/18103407/155812394-8cf93072-303d-49a0-b992-10bfc796e6eb.jpg)

I've been able to implement this by adding the checkbox name [from the schema] to the collection cards.  Here is a link to the notion page  https://talented-work-a0b.notion.site/Checklist-128b92cbe975470c8a8594ad232cf3da