### PR TITLE
Widen horizontal padding on small screens

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -557,8 +557,8 @@
 
 .notion-page {
   width: var(--notion-max-width);
-  padding-left: calc(min(12px, 8vw));
-  padding-right: calc(min(12px, 8vw));
+  padding-left: calc(min(16px, 8vw));
+  padding-right: calc(min(16px, 8vw));
 }
 
 .notion-full-width {

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1975,11 +1975,6 @@ svg.notion-page-icon {
 }
 
 @media only screen and (max-width: 730px) {
-  .notion-page {
-    padding-left: 2vw;
-    padding-right: 2vw;
-  }
-
   .notion-asset-wrapper {
     max-width: 100%;
   }


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->

On a iPhone 12 Pro screen, horizontal padding is calculated as 7.8px which looks awful for such content-rich website:

<img width="643" alt="image" src="https://user-images.githubusercontent.com/44045911/156980511-b437dcc1-28e2-46d0-af84-9242de5d0d9b.png">

On super.so the minimum padding is 24px. That's a lot so 16px would do it.