### PR TITLE
Show the checkbox text on collection card

### DIFF
--- a/packages/react-notion-x/src/components/property.tsx
+++ b/packages/react-notion-x/src/components/property.tsx
@@ -143,7 +143,9 @@ export const Property: React.FC<{
         case 'checkbox':
           const isChecked = data && data[0][0] === 'Yes'
 
-          return <Checkbox isChecked={isChecked} blockId={undefined} />
+          return <div className='notion-property-checkbox-container'>
+            <Checkbox isChecked={isChecked} blockId={undefined} />
+            <span className='notion-property-checkbox-text'>{schema.name}</span></div>
 
         case 'url':
           // TODO: refactor to less hackyh solution

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1247,6 +1247,19 @@ svg.notion-page-icon {
   max-height: 100%;
 }
 
+.notion-collection-card .notion-property-checkbox-container {
+  display: flex;
+}
+
+.notion-property-checkbox-text {
+  display: none;
+}
+
+.notion-collection-card .notion-property-checkbox-text {
+  display: inline-block;
+  margin-left: 6px;
+}
+
 .notion-property-checkbox {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
The library only shows a checkbox on a collection card without the checkbox's name. 
**This is what it looks like currently** 
![check-list-w-o-text](https://user-images.githubusercontent.com/18103407/155812329-91816487-a738-485a-8065-d1f57871174b.jpg)

**And this what it looks like on notion**
![check-list-w-text](https://user-images.githubusercontent.com/18103407/155812394-8cf93072-303d-49a0-b992-10bfc796e6eb.jpg)

I've been able to implement this by adding the checkbox name [from the schema] to the collection cards.  Here is a link to the notion page  https://talented-work-a0b.notion.site/Checklist-128b92cbe975470c8a8594ad232cf3da