### PR TITLE
feat: add page content only feature

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -40,6 +40,7 @@ interface BlockProps {
   pageFooter?: React.ReactNode
   pageAside?: React.ReactNode
   pageCover?: React.ReactNode
+  pageContentOnly?: boolean
 
   hideBlockId?: boolean
   disableHeader?: boolean
@@ -76,6 +77,7 @@ export const Block: React.FC<BlockProps> = (props) => {
     pageFooter,
     pageAside,
     pageCover,
+    pageContentOnly,
     hideBlockId,
     disableHeader
   } = props
@@ -99,6 +101,15 @@ export const Block: React.FC<BlockProps> = (props) => {
     // fallthrough
     case 'page':
       if (level === 0) {
+        if (pageContentOnly) {
+          // only render child blocks
+          return (
+            <article className='notion-page-content-inner'>
+              {children}
+            </article>
+          )
+        }
+
         const {
           page_icon = defaultPageIcon,
           page_cover = defaultPageCover,

--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -43,6 +43,7 @@ export interface NotionRendererProps {
   pageFooter?: React.ReactNode
   pageAside?: React.ReactNode
   pageCover?: React.ReactNode
+  pageContentOnly?: boolean
 
   blockId?: string
   hideBlockId?: boolean
@@ -119,6 +120,7 @@ export const NotionRenderer: React.FC<NotionRendererProps> = ({
 export const NotionBlockRenderer: React.FC<NotionBlockRendererProps> = ({
   level = 0,
   blockId,
+  pageContentOnly = false,
   ...props
 }) => {
   const { recordMap } = useNotionContext()
@@ -134,7 +136,7 @@ export const NotionBlockRenderer: React.FC<NotionBlockRendererProps> = ({
   }
 
   return (
-    <Block key={id} level={level} block={block} {...props}>
+    <Block key={id} level={level} block={block} pageContentOnly={pageContentOnly} {...props}>
       {block?.content?.map((contentBlockId) => (
         <NotionBlockRenderer
           key={contentBlockId}


### PR DESCRIPTION
First, thank you for your work in such a solid library.

## Why is this change needed?

I liked the theme which automatically comes with `NotionRenderer`, but I needed a way to get contents of a page as a raw HTML to customize it furtuer, without the extra components like title, footer, cover, etc.

## How is this change used?

Previously, the following code will render with the default theme:


<table>
<tr><td>Code</td><td>Preview</td></tr>
<tr>
<td>

```jsx
<NotionRenderer
  recordMap={recordMap}
  rootPageId={site.rootNotionPageId}
  ...
/>
```

</td>
<td>

![image](https://user-images.githubusercontent.com/13298429/159112533-97e45587-2341-4e78-aa06-d7866203a6ac.png)

</td>
</tr>
</table>


With the change, you can add `pageContentOnly={true}` as a property and the `NotionRenderer` component will render in raw HTML:


<table>
<tr><td>Code</td><td>Preview</td></tr>
<tr>
<td>

```jsx
<NotionRenderer
  recordMap={recordMap}
  rootPageId={site.rootNotionPageId}
  pageContentOnly={true}
  ...
/>
```

</td>
<td>

![image](https://user-images.githubusercontent.com/13298429/159112649-dac15b03-61b7-4c29-98e4-1e4aedafe39d.png)

</td>
</tr>
</table>

## Notion Page used

Page used is my page [here](https://www.notion.so/ntcho/About-f19c6d673e474fc2894862dee9d201fe), duplicated from Travis Fischer's original notion page.