### PR TITLE
fix: inline gallery undefined error

### DIFF
--- a/packages/react-notion-x/src/components/collection-view-gallery.tsx
+++ b/packages/react-notion-x/src/components/collection-view-gallery.tsx
@@ -30,7 +30,7 @@ export const CollectionViewGallery: React.FC<CollectionViewProps> = ({
     <Gallery
       collectionView={collectionView}
       collection={collection}
-      blockIds={collectionData['collection_group_results'].blockIds}
+      blockIds={collectionData.blockIds}
     />
   )
 }

--- a/packages/react-notion-x/src/components/collection-view-list.tsx
+++ b/packages/react-notion-x/src/components/collection-view-list.tsx
@@ -28,7 +28,7 @@ export const CollectionViewList: React.FC<CollectionViewProps> = ({
 
   return (
     <List
-      blockIds={collectionData['collection_group_results'].blockIds}
+      blockIds={collectionData.blockIds}
       collection={collection}
       collectionView={collectionView}
     />

--- a/packages/react-notion-x/src/components/collection-view-table.tsx
+++ b/packages/react-notion-x/src/components/collection-view-table.tsx
@@ -43,7 +43,7 @@ export const CollectionViewTable: React.FC<CollectionViewProps> = ({
 
   return (
     <Table
-      blockIds={collectionData['collection_group_results'].blockIds}
+      blockIds={collectionData.blockIds}
       collection={collection}
       collectionView={collectionView}
       padding={padding}


### PR DESCRIPTION
This pull request fixes NotionX/react-notion-x#226.

## Current problem

`CollectionViewGallery`, `CollectionViewList`, `CollectionViewTable` are affected by external source (can't confirm, but possibly related to Notion's latest change in API with the collection view design update).

The problem seems to be originated from the modification of the props being passed to these objects:

<table>
<tr><td>Previous props</td><td>Current props</td></tr>
<tr>
<td>

```js
{
  collection: {
    id: 'ba828d5c-47bd-4c26-...',
    ...
  },
  collectionView: {
    id: '0981a186-f238-44ac-...',
    ...
  },
  collectionData: {
    type: 'results',
    collection_group_results: {
      blockIds: [
        'c6bcd16d-ff46-4b7c-...',
      ],
    },
    hasMore: false
  },
  padding: 96,
  width: 1024
}
```

</td>
<td>

```js
{
  collection: {
    id: 'ba828d5c-47bd-4c26-...',
    ...
  },
  collectionView: {
    id: '0981a186-f238-44ac-...',
    ...
  },
  collectionData: {
    type: 'results',
    blockIds: [
      'c6bcd16d-ff46-4b7c-...',
    ],
    hasMore: false
  },
  padding: 96,
  width: 1024
}
```

</td>
</tr>
</table>

## Changes made

Replaced all occurrences referencing `collectionData['collection_group_results'].blockIds` into `collectionData.blockIds`.

> I couldn't build the source and test this change myself, but applying this modification directly to the build files fixed this issue. Please test this change before merging it.

## Notion page for testing

https://tall-flock-373.notion.site/Problem-with-gallery-page-8a4e3d43f7f54323a2d4aca5647a6b5a (from #226)