### PR TITLE
fix response 401 due to auth token not passed as bearer token

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -543,7 +543,7 @@ export class NotionAPI {
     }
 
     if (this._authToken) {
-      headers.cookie = `token_v2=${this._authToken}`
+      headers['Authorization'] = `Bearer ${this._authToken}`
     }
 
     if (this._activeUser) {


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->

This update should fix the issue that passing `authToken` but still getting 401 response

It should be passed as `Authorization` bearer token according to this notion page:
https://developers.notion.com/docs/authorization