### PR TITLE
match simple table column widths with Notion

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -794,7 +794,8 @@ export const Block: React.FC<BlockProps> = (props) => {
                 key={column}
                 className={color ? `notion-${color}` : ''}
                 style={{
-                  width: formatMap?.[column]?.width || 120
+                  minWidth: 120,
+                  maxWidth: 240
                 }}
               >
                 <div className='notion-simple-table-cell'>


### PR DESCRIPTION
#### Description

In Notion, Cells of Simple Table has `min-width` and `max-width` instead of `width`. 

So, changed the styles as per Notion styles.

#### Notion Test Page ID
1e739b87549e406a9461d2a7e4ff7845
<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
