### PR TITLE
✍🏼README.md includes docs on using auth for private pages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,9 +66,20 @@ export default ({ recordMap }) => (
 )
 ```
 
-You may optionally pass an `authToken` to the API if you want to access private Notion resources.
-
 Note: for heavier blocks, you'll have to opt into using them via `NotionRenderer.components`. These are not included in the default `NotionRenderer` export because they're too heavyweight for a lot of use cases.
+
+## Private Pages
+
+You may optionally pass an `authToken` and `activeUser` to the API if you want to access private Notion pages. Both can be retrieved from your web browser. Once you are viewing your workpace, open your Development Tools > Application > Cookie > and Copy/Paste the `token_v2` and `notion_user_id`. Respectively, activeUser: notion_user_id, authToken: token_v2.
+
+Here's a quick code snippet for the client usage when implementing process env for tokens:
+```tsx
+const notion = new NotionAPI({
+  activeUser: process.env.NOTION_ACTIVE_USER, 
+  authToken: process.env.NOTION_TOKEN_V2
+  })
+```
+If issue arises where the pageId is not found, restart your local host instance.
 
 ## Styles
 


### PR DESCRIPTION
#### Providing Auth for Private Notion Workspaces

- adds documentation on providing auth to the Notion Client for private pages
- Code Snippet provides implements node env

DEMO: You can preview the README.md at my branch here: https://github.com/ggiande/react-notion-x/tree/ggiande/doc-private-page-auth

This update does not reference any specific Notion page that is publicly available because it's about a private Notion page.

Fixes #267 

##### Summary of files changed
- README.md: added a guide on retrieving the necessary tokens from a cookie in the browser

