### PR TITLE
Remove styles inconsistency

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -834,10 +834,6 @@ svg.notion-page-icon {
   flex-direction: column;
 }
 
-.notion-block {
-  padding: 3px 2px;
-}
-
 .notion .notion-code {
   font-size: 85%;
 }


### PR DESCRIPTION
This style breaks dividers, and only applies when `hideBlockId` is enabled

#### Description

This padding adds some weird borders around the sides of a divider

![image](https://user-images.githubusercontent.com/68407783/165394019-bfc1bbc2-960f-4fee-9ee7-47b64821d5c3.png)

![image](https://user-images.githubusercontent.com/68407783/165393964-4cb1b560-d9f9-4e07-9c54-0751dff94a9c.png)
 
It also only applies when `hideBlockId` is enabled since it doesn't match `notion-block-{ID}`

![image](https://user-images.githubusercontent.com/68407783/165394271-4e32c2c7-50c4-41ee-9eb8-4a905b78dc00.png)

![image](https://user-images.githubusercontent.com/68407783/165394303-c9d81120-6c46-49e7-b80e-c3e668c5aa56.png)

#### Notion Test Page ID

`ID` 0be6efce9daf42688f65c76b89f8eb27
`URL` https://react-notion-x-demo.transitivebullsh.it/0be6efce9daf42688f65c76b89f8eb27

To reproduce, remove the ID from the divider's `notion-block` class name which is what `hideBlockId` would set it to