### PR TITLE
feat(add support for private Notion page assets)

### DIFF
--- a/packages/notion-utils/src/get-page-image-urls.ts
+++ b/packages/notion-utils/src/get-page-image-urls.ts
@@ -1,6 +1,7 @@
 import * as types from 'notion-types'
 import { isUrl } from './is-url'
 import { getBlockIcon } from './get-block-icon'
+import { ExtendedRecordMap } from 'notion-types'
 
 /**
  * Gets URLs of all images contained on the given page.
@@ -10,7 +11,11 @@ export const getPageImageUrls = (
   {
     mapImageUrl
   }: {
-    mapImageUrl: (url: string, block: types.Block) => string | null
+    mapImageUrl: (
+      url: string,
+      block: types.Block,
+      recordMap?: ExtendedRecordMap
+    ) => string | null
   }
 ): string[] => {
   const blockIds = Object.keys(recordMap.block)
@@ -71,7 +76,7 @@ export const getPageImageUrls = (
       return images
     })
     .filter(Boolean)
-    .map(({ block, url }) => mapImageUrl(url, block))
+    .map(({ block, url }) => mapImageUrl(url, block, recordMap))
     .filter(Boolean)
 
   return Array.from(new Set(imageUrls))

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -169,7 +169,7 @@ export const Block: React.FC<BlockProps> = (props) => {
                     ) : (
                       <div className='notion-page-cover-wrapper'>
                         <LazyImage
-                          src={mapImageUrl(page_cover, block)}
+                          src={mapImageUrl(page_cover, block, recordMap)}
                           alt={getTextContent(properties?.title)}
                           priority={true}
                           className='notion-page-cover'

--- a/packages/react-notion-x/src/components/page-icon.tsx
+++ b/packages/react-notion-x/src/components/page-icon.tsx
@@ -38,12 +38,11 @@ export const PageIconImpl: React.FC<{
     const title = getBlockTitle(block, recordMap)
 
     if (icon && isUrl(icon)) {
-      const url = mapImageUrl(icon, block)
       isImage = true
 
       content = (
         <LazyImage
-          src={url}
+          src={mapImageUrl(icon, block, recordMap)}
           alt={title || 'page icon'}
           className={cs(className, 'notion-page-icon')}
         />

--- a/packages/react-notion-x/src/third-party/collection-card.tsx
+++ b/packages/react-notion-x/src/third-party/collection-card.tsx
@@ -42,7 +42,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
         contentBlock.format?.display_source
 
       if (source) {
-        const src = mapImageUrl(source, contentBlock)
+        const src = mapImageUrl(source, contentBlock, recordMap)
         const caption = contentBlock.properties?.caption?.[0]?.[0]
 
         coverContent = (
@@ -66,9 +66,11 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
     if (page_cover) {
       const coverPosition = (1 - page_cover_position) * 100
 
+      // Private UGC requires a Signed URL; thus, check if there's a Signed URL
+      //   for this block and fallback to the `page_cover` value if not.
       coverContent = (
         <LazyImage
-          src={mapImageUrl(page_cover, block)}
+          src={mapImageUrl(page_cover, block, recordMap)}
           alt={getTextContent(block.properties?.title)}
           style={{
             objectFit: coverAspect,

--- a/packages/react-notion-x/src/types.ts
+++ b/packages/react-notion-x/src/types.ts
@@ -5,7 +5,11 @@ export type MapPageUrlFn = (
   pageId: string,
   recordMap?: types.ExtendedRecordMap | undefined
 ) => string
-export type MapImageUrlFn = (url: string, block: types.Block) => string
+export type MapImageUrlFn = (
+  url: string,
+  block: types.Block,
+  recordMap?: types.ExtendedRecordMap
+) => string
 export type SearchNotionFn = (
   params: types.SearchParams
 ) => Promise<types.SearchResults>

--- a/packages/react-notion-x/src/utils.ts
+++ b/packages/react-notion-x/src/utils.ts
@@ -1,9 +1,13 @@
-import { Block, BlockMap } from 'notion-types'
+import { Block, BlockMap, ExtendedRecordMap } from 'notion-types'
 import { isUrl, formatDate, formatNotionDateTime } from 'notion-utils'
 
 export { isUrl, formatDate, formatNotionDateTime }
 
-export const defaultMapImageUrl = (url: string, block: Block) => {
+export const defaultMapImageUrl = (
+  url: string,
+  block: Block,
+  recordMap?: ExtendedRecordMap
+) => {
   if (!url) {
     return null
   }
@@ -16,6 +20,8 @@ export const defaultMapImageUrl = (url: string, block: Block) => {
   if (url.startsWith('https://images.unsplash.com')) {
     return url
   }
+
+  url = recordMap?.signed_urls[url] ?? url
 
   try {
     const u = new URL(url)


### PR DESCRIPTION
#### Description
Traverses a page's blocks (for `collection_view` support) to generate
Signed URLs for images. Also expands `defaultMapImageUrl` to support
lookups for UGC (user-generated content) on Page Covers and Page Icons.
(Which will follow a form similar to
 `https://notion.so/<UUID>/<filename>.<ext>`. Since the OG
 implementation maps these assets to `block.id`, which refers to the
 Page, only one of Cover / Icon were allowed to be UGC.)


#### Notion Test Page ID

I used the shipped examples in `examples/full`, so `067dd719a912471ea9a3ac10710e7fdf`.

This is intended to work on private pages and didn't appear to alter public pages.

**Note:** It _seems_ that image loading is slower from AWS now. **But**, I believe this is due to one of the GIFs on my test page being ~30MB. 😅 