### PR TITLE
Add SimpleTable Block to notion-compat

### DIFF
--- a/packages/notion-compat/src/convert-block.ts
+++ b/packages/notion-compat/src/convert-block.ts
@@ -317,11 +317,36 @@ export function convertBlock({
       break
 
     case 'table':
-      // TODO
+      if (blockDetails.table_width && blockDetails.table_width > 0) {
+        // There is no API to get the column ID. Used the index instead.
+        compatBlock.format.table_block_column_order = Array.from(
+          { length: blockDetails.table_width },
+          (_, i) => '' + i
+        )
+        compatBlock.format.table_block_column_format =
+          compatBlock.format.table_block_column_order.map((order) => {
+            return {
+              [order]: {
+                // TODO: The SimpleTable column has no width and color. API is not supported.
+                // width: 155,
+                // color:
+              }
+            }
+          })
+      }
+      if (blockDetails.has_column_header) {
+        compatBlock.format.table_block_column_header =
+          blockDetails.has_column_header
+      }
+      if (blockDetails.has_row_header) {
+        compatBlock.format.table_block_row_header = blockDetails.has_row_header
+      }
       break
 
     case 'table_row':
-      // TODO
+      compatBlock.properties = {
+        ...block.table_row?.cells?.map((cell) => convertRichText(cell))
+      }
       break
 
     case 'pdf':


### PR DESCRIPTION
#### Description

Add SimpleTable Block to notion-compat.

I found some unsupported items of API.
1. There is no API to get the column ID. Used the index instead.
1. The SimpleTable column has no width and color. API is not supported.

I have left a comment on these in the source code.
1. https://github.com/nakaiyusaku/react-notion-x/commit/1f0ab29f11ebd39f2dc5e35a369ba476d503d547#diff-e25fbbad19a8dad7ae798b5c4491230f038bc4a86b04862e7227bb01f95b116bR321
1. https://github.com/nakaiyusaku/react-notion-x/commit/1f0ab29f11ebd39f2dc5e35a369ba476d503d547#diff-e25fbbad19a8dad7ae798b5c4491230f038bc4a86b04862e7227bb01f95b116bR330

#### Notion Test Page ID

https://react-notion-x-official-api-demo.transitivebullsh.it/9d9814f3220a4b3bbc2481ad6fd7c913
