### PR TITLE
Group top-level list items

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -433,9 +433,9 @@ export const Block: React.FC<BlockProps> = (props) => {
           {block.properties && (
             <li className={cs('notion-list', listTypeCls, blockId)}>
               <Text value={block.properties.title} block={block} />
+              {children}
             </li>
           )}
-          {children}
         </>
       )
     }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -18,7 +18,7 @@ import { Audio } from './components/audio'
 import { File } from './components/file'
 import { LazyImage } from './components/lazy-image'
 import { useNotionContext } from './context'
-import { cs, getListNumber, isUrl } from './utils'
+import { cs, isUrl } from './utils'
 import { Text } from './components/text'
 import { SyncPointerBlock } from './components/sync-pointer-block'
 import { AssetWrapper } from './components/asset-wrapper'
@@ -424,46 +424,20 @@ export const Block: React.FC<BlockProps> = (props) => {
     case 'bulleted_list':
     // fallthrough
     case 'numbered_list': {
-      const wrapList = (content: React.ReactNode, start?: number) =>
-        block.type === 'bulleted_list' ? (
-          <ul className={cs('notion-list', 'notion-list-disc', blockId)}>
-            {content}
-          </ul>
-        ) : (
-          <ol
-            start={start}
-            className={cs('notion-list', 'notion-list-numbered', blockId)}
-          >
-            {content}
-          </ol>
-        )
-
-      let output: JSX.Element | null = null
-
-      if (block.content) {
-        output = (
-          <>
-            {block.properties && (
-              <li>
-                <Text value={block.properties.title} block={block} />
-              </li>
-            )}
-            {wrapList(children)}
-          </>
-        )
-      } else {
-        output = block.properties ? (
-          <li>
-            <Text value={block.properties.title} block={block} />
-          </li>
-        ) : null
-      }
-
-      const isTopLevel =
-        block.type !== recordMap.block[block.parent_id]?.value?.type
-      const start = getListNumber(block.id, recordMap.block)
-
-      return isTopLevel ? wrapList(output, start) : output
+      const listTypeCls =
+        block.type === 'bulleted_list'
+          ? 'notion-list-disc'
+          : 'notion-list-numbered'
+      return (
+        <>
+          {block.properties && (
+            <li className={cs('notion-list', listTypeCls, blockId)}>
+              <Text value={block.properties.title} block={block} />
+            </li>
+          )}
+          {children}
+        </>
+      )
     }
 
     case 'embed':

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -424,14 +424,10 @@ export const Block: React.FC<BlockProps> = (props) => {
     case 'bulleted_list':
     // fallthrough
     case 'numbered_list': {
-      const listTypeCls =
-        block.type === 'bulleted_list'
-          ? 'notion-list-disc'
-          : 'notion-list-numbered'
       return (
         <>
           {block.properties && (
-            <li className={cs('notion-list', listTypeCls, blockId)}>
+            <li className={cs(blockId)}>
               <Text value={block.properties.title} block={block} />
               {children}
             </li>

--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import mediumZoom from '@fisch0920/medium-zoom'
-import { ExtendedRecordMap } from 'notion-types'
+import { Block as BlockType, ExtendedRecordMap } from 'notion-types'
 
 import {
   MapPageUrlFn,
@@ -10,6 +10,7 @@ import {
 } from './types'
 import { Block } from './block'
 import { useNotionContext, NotionContextProvider } from './context'
+import { cs } from './utils'
 
 export const NotionRenderer: React.FC<{
   recordMap: ExtendedRecordMap
@@ -137,16 +138,77 @@ export const NotionBlockRenderer: React.FC<{
 
   return (
     <Block key={id} level={level} block={block} {...props}>
-      {block?.content?.map((contentBlockId) => (
-        <NotionBlockRenderer
-          key={contentBlockId}
-          blockId={contentBlockId}
-          level={level + 1}
-          {...props}
-        />
-      ))}
+      <BlockChildrenRenderer level={level} block={block} {...props} />
     </Block>
   )
+}
+
+const BlockChildrenRenderer: React.FC<{
+  className?: string
+  bodyClassName?: string
+  header?: React.ReactNode
+  footer?: React.ReactNode
+  disableHeader?: boolean
+
+  block: BlockType
+  hideBlockId?: boolean
+  level?: number
+}> = ({ level, block, ...props }) => {
+  const { recordMap } = useNotionContext()
+  const contentNodes = []
+
+  if (!block.content) {
+    return <></>
+  }
+
+  const wrapList = (content: React.ReactElement[]) =>
+    block.type === 'bulleted_list' ? (
+      <ul className={cs('notion-list', 'notion-list-disc')}>{content}</ul>
+    ) : (
+      <ol className={cs('notion-list', 'notion-list-numbered')}>{content}</ol>
+    )
+
+  for (let i = 0; i < block.content.length; ) {
+    const nextChildBlock = recordMap.block[block.content[i]]?.value
+    const nextChildBlockType = nextChildBlock?.type
+
+    let nextChildGroup = [block.content[i]]
+    if (
+      nextChildBlockType === 'bulleted_list' ||
+      nextChildBlockType === 'numbered_list'
+    ) {
+      let j = i
+      while (
+        j < block.content.length &&
+        recordMap.block[block.content[j]]?.value?.type === nextChildBlockType
+      ) {
+        j++
+      }
+      nextChildGroup = block.content.slice(i, j)
+    }
+
+    const nextRenderedGroup = nextChildGroup.map((nextChildId) => (
+      <NotionBlockRenderer
+        key={nextChildId}
+        blockId={nextChildId}
+        level={level + 1}
+        {...props}
+      />
+    ))
+
+    if (
+      nextChildBlockType === 'bulleted_list' ||
+      nextChildBlockType === 'numbered_list'
+    ) {
+      contentNodes.push(wrapList(nextRenderedGroup))
+    } else {
+      contentNodes.push(...nextRenderedGroup)
+    }
+
+    i += nextChildGroup.length
+  }
+
+  return <>{contentNodes}</>
 }
 
 function getMediumZoomMargin() {


### PR DESCRIPTION
#### Description

Top-level list items were rendered within seperate list containers. A top-level list that contains 2 items were rendered as:

```html
<ul>
  <li></li>
</ul>
<ul>
  <li></li>
</ul>
```

instead of the more comprehensible form:

```html
<ul>
  <li></li>
  <li></li>
</ul>
```

This PR addresses this issue and changes the way top-level list items are grouped and rendered.

Here is a screenshot after changes:

![screenshot](https://user-images.githubusercontent.com/29401356/173984242-10544314-0083-49c3-a46a-f748539ab343.png)

#### Notion Test Page ID

de14421f13914ac7b528fa2e31eb1455