### PR TITLE
Adding has_children to BaseBlock type

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -108,6 +108,7 @@ export interface BaseBlock {
   created_time: number
   last_edited_time: number
   alive: boolean
+  has_children: boolean
   created_by_table: string
   created_by_id: ID
   last_edited_by_table: string


### PR DESCRIPTION

#### Description

As declared on Notion API Docs 
https://developers.notion.com/reference/block#block-object-keys
![Screen Shot 2022-06-29 at 09 01 44](https://user-images.githubusercontent.com/11268492/176335580-6b58068b-b0f8-4777-bf3c-8c541b6d91b9.png)


#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
