### PR TITLE
feat(doc): fix typo for examples folder

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -14,7 +14,7 @@ cd react-notion-x
 yarn
 ```
 
-This will install dependencies and link all of the local packages together using `lerna`. This includes the `example` projects which will now point to the local version of your packages.
+This will install dependencies and link all of the local packages together using `lerna`. This includes the `examples` projects which will now point to the local version of your packages.
 
 ```bash
 yarn dev
@@ -22,20 +22,21 @@ yarn dev
 
 This starts compiling the packages into their respective `build` folders. Under the hood, it is running `tsc --watch` and `tsup --watch`, so every time you make a change to one of the packages, the build will be updated automatically as long as this command is running.
 
-With `yarn dev` running in one tab, we recommend opening a second tab and navigating to the `example/minimal` directory.
+With `yarn dev` running in one tab, we recommend opening a second tab and navigating to the `examples/minimal` directory.
 
 ```bash
-cd example/minimal
+cd examples/minimal
 yarn dev
 ```
 
-Running `yarn dev` from the `example/minimal` directory will start the example project's Next.js dev server. This project should be using your locally built version of the libraries because they have been linked using `lerna`.
+Running `yarn dev` from the `examples/minimal` directory will start the example project's Next.js dev server. This project should be using your locally built version of the libraries because they have been linked using `lerna`.
 
 You should now be able to open `http://localhost:3000` to view and debug the example project.
 
 ### Gotchas
 
-Whenever you make a change to one of the packages, the `yarn dev` from the project root will re-compile that package, and the `yarn dev` from the example project's Next.js dev server should hot-reload it in the browser.
+Whenever you make a change to one of the packages, the `yarn dev` from the project root will re-compile that package, and the `yarn dev` from the 
+project's Next.js dev server should hot-reload it in the browser.
 
 Sometimes, this process gets a little out of whack, and if you're not sure what's going on, I usually just quit one or both of the `yarn dev` commands and restart them.
 

--- a/contributing.md
+++ b/contributing.md
@@ -14,7 +14,7 @@ cd react-notion-x
 yarn
 ```
 
-This will install dependencies and link all of the local packages together using `lerna`. This includes the `examples` projects which will now point to the local version of your packages.
+This will install dependencies and link all of the local packages together using `lerna`. This includes the example projects which will now point to the local version of your packages.
 
 ```bash
 yarn dev
@@ -35,8 +35,7 @@ You should now be able to open `http://localhost:3000` to view and debug the exa
 
 ### Gotchas
 
-Whenever you make a change to one of the packages, the `yarn dev` from the project root will re-compile that package, and the `yarn dev` from the 
-project's Next.js dev server should hot-reload it in the browser.
+Whenever you make a change to one of the packages, the `yarn dev` from the project root will re-compile that package, and the `yarn dev` from the example project's Next.js dev server should hot-reload it in the browser.
 
 Sometimes, this process gets a little out of whack, and if you're not sure what's going on, I usually just quit one or both of the `yarn dev` commands and restart them.
 


### PR DESCRIPTION
#### Description

The name of the folder that contains examples for using React Notion X is `examples`, not `example`. I just fix this typo.
<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID
N/A

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
