### PR TITLE
fix TypeError in addSignedUrls

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -217,7 +217,7 @@ export class NotionAPI {
     }
 
     const allFileInstances = contentBlockIds.flatMap((blockId) => {
-      const block = recordMap.block[blockId].value
+      const block = recordMap.block[blockId]?.value
 
       if (
         block &&


### PR DESCRIPTION
#### Description

In some cases a content page id is not in the block object, this can cause a `TypeError: Cannot read property 'value' of undefined`

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
