### PR TITLE
feat: support bodyClassName when omitting fullPage

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -261,22 +261,21 @@ export const Block: React.FC<BlockProps> = (props) => {
                 page_full_width && 'notion-full-width',
                 page_small_text && 'notion-small-text',
                 blockId,
-                className,
-                bodyClassName
+                className
               )}
             >
               <div className='notion-viewport' />
 
               {pageHeader}
+              <div className={`notion-block-content ${bodyClassName}`}>
+                {(block.type === 'collection_view_page' ||
+                  (block.type === 'page' &&
+                    block.parent_table === 'collection')) && (
+                  <components.Collection block={block} ctx={ctx} />
+                )}
 
-              {(block.type === 'collection_view_page' ||
-                (block.type === 'page' &&
-                  block.parent_table === 'collection')) && (
-                <components.Collection block={block} ctx={ctx} />
-              )}
-
-              {block.type !== 'collection_view_page' && children}
-
+                {block.type !== 'collection_view_page' && children}
+              </div>
               {pageFooter}
             </main>
           )


### PR DESCRIPTION
#### Description

Probably fixes #316 

When `fullPage` of component `<NotionRenderer>` is omitted or set to `false`, both `className` and `bodyClassName` are assigned to the `<main>` element.

```
<main
              className={cs(
                'notion',
                darkMode ? 'dark-mode' : 'light-mode',
                'notion-page',
                page_full_width && 'notion-full-width',
                page_small_text && 'notion-small-text',
                blockId,
                className
              )}
            >
</main>
```
I think this will:
- defeat the purpose of having two separate props: `className` and `bodyClassName` of `<NotionRenderer>`.
- take away the users' opportunity for controlling the markup with CSS.

So I wrapped the children blocks in an extra element and added `bodyClassName` to it.
<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
