### PR TITLE
fix: make collectionView parameter optional

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -309,7 +309,7 @@ export class NotionAPI {
   public async getCollectionData(
     collectionId: string,
     collectionViewId: string,
-    collectionView: any,
+    collectionView?: any,
     {
       limit = 9999,
       searchQuery = '',


### PR DESCRIPTION
#### Description
The `getCollectionData` only requires two parameters, as shown in this [README](https://github.com/NotionX/react-notion-x/tree/master/packages/notion-client).

However, the typing makes it look like it requires a third parameter, `collectionView`, which is in fact optional. If users din't pass `collectionView` to the function, Typescript will complain.

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

Just try passing these two ids to `getCollectionData`, and the response is successful.

```
const collectionId = '2d8aec23-8281-4a94-9090-caaf823dd21a'
const collectionViewId = 'ab639a5a-853e-45e1-9ef7-133b486c0acf'
```

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
