### PR TITLE
Only add signed urls for `secure.notion-static.com` urls

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -235,7 +235,7 @@ export class NotionAPI {
         // console.log(block, source)
 
         if (source) {
-          if (source.indexOf('youtube') >= 0 || source.indexOf('vimeo') >= 0) {
+          if (!source.includes('secure.notion-static.com')) {
             return []
           }
 


### PR DESCRIPTION
#### Description

Only add signed urls for `secure.notion-static.com` urls

Fix #331 

#### Notion Test Page ID

https://brave-iberis-6ea.notion.site/Videos-5af3d63c840e458e92c09c2ec6cd71b3
https://react-notion-x-demo.transitivebullsh.it/5af3d63c840e458e92c09c2ec6cd71b3

