### PR TITLE
FEAT: Added support for the newest version of database filters

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -332,6 +332,18 @@ export class NotionAPI {
       collectionView?.format?.board_columns_by ||
       collectionView?.format?.collection_group_by
 
+    let filters = []
+    if (collectionView.format?.property_filters) {
+      filters = collectionView.format?.property_filters.map((filterObj) => {
+        // console.log('map filter', filterObj)
+        //get the inner filter
+        return {
+          filter: filterObj.filter.filter,
+          property: filterObj.filter.property
+        }
+      })
+    }
+
     let loader: any = {
       type: 'reducer',
       reducers: {
@@ -343,6 +355,10 @@ export class NotionAPI {
       },
       sort: [],
       ...collectionView?.query2,
+      filter: {
+        filters: filters,
+        operator: 'and'
+      },
       searchQuery,
       userTimeZone
     }
@@ -421,16 +437,6 @@ export class NotionAPI {
         }
       }
 
-      //TODO: started working on the filters. This doens't seem to quite work yet.
-      // let filters = collectionView.format?.property_filters.map(filterObj => {
-      //   console.log('map filter', filterObj)
-      //   //get the inner filter
-      //   return {
-      //     filter: filterObj.filter.filter,
-      //     property: filterObj.filter.property
-      //   }
-      // })
-
       const reducerLabel = isBoardType ? 'board_columns' : `${type}_groups`
       loader = {
         type: 'reducer',
@@ -448,12 +454,12 @@ export class NotionAPI {
         },
         ...collectionView?.query2,
         searchQuery,
-        userTimeZone
+        userTimeZone,
         //TODO: add filters here
-        // filter: {
-        //   filters: filters,
-        //   operator: 'and'
-        // }
+        filter: {
+          filters: filters,
+          operator: 'and'
+        }
       }
     }
 

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -338,8 +338,8 @@ export class NotionAPI {
         // console.log('map filter', filterObj)
         //get the inner filter
         return {
-          filter: filterObj.filter.filter,
-          property: filterObj.filter.property
+          filter: filterObj?.filter?.filter,
+          property: filterObj?.filter?.property
         }
       })
     }


### PR DESCRIPTION
#### Description

Notion changes how their databases work a while back and updated how users can filter them. This update adds support for that newest update.

Now notion-react-x can show databases even if they have filters on them. This should work for all types of views.

#### Notion Test Page ID

multiple different text examples including older version of databases that still work.

84696b02b91d45a4a879ff572c23cc93
3271d83e87a14a42b5a53fd16c4339a7?v=ef3aeeb35e3045dc9b04abba22c10648
6f6138a8d9ab4e2b85a0f664d035b9a3?v=ca9b476a978d430a81ceac957b28dee7
a0cb6346eaba4a4f930a4c4206942b1e

![image](https://user-images.githubusercontent.com/21371266/181116107-c3ade658-fbf8-4e67-b2d3-4ec64f211ec8.png)
![image](https://user-images.githubusercontent.com/21371266/181116245-a4aeded5-c963-4e5f-b1f0-29b6e0e362ed.png)

