### PR TITLE
Fix for getting signed urls

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -231,7 +231,11 @@ export class NotionAPI {
         // console.log(block, source)
 
         if (source) {
-          if (source.indexOf('youtube') >= 0 || source.indexOf('vimeo') >= 0) {
+          if (
+            source.indexOf('youtube') >= 0 ||
+            source.indexOf('vimeo') >= 0 ||
+            source.indexOf('loom') >= 0
+          ) {
             return []
           }
 

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -227,10 +227,7 @@ export class NotionAPI {
           block.type === 'video' ||
           block.type === 'file')
       ) {
-        const source =
-          block.type === 'page'
-            ? block.format?.page_cover
-            : block.properties?.source?.[0]?.[0]
+        const source = block.properties?.source?.[0]?.[0]
         // console.log(block, source)
 
         if (source) {

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -225,8 +225,7 @@ export class NotionAPI {
           block.type === 'audio' ||
           (block.type === 'image' && block.file_ids?.length) ||
           block.type === 'video' ||
-          block.type === 'file' ||
-          block.type === 'page')
+          block.type === 'file')
       ) {
         const source =
           block.type === 'page'


### PR DESCRIPTION
Notion API is throwing an error when a signed URL is requested for page cover.  Removing it solves the problem.

Resolves #331 