### PR TITLE
Display newlines properly in simple tables

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2578,6 +2578,7 @@ svg.notion-page-icon {
 .notion-simple-table td {
   border: 1px solid var(--fg-color-5);
   padding: 8px 8px;
+  white-space: pre-wrap;
 }
 
 .notion-external {


### PR DESCRIPTION
## Description
Fix for #199 

This PR fixes the newline issue in simple tables.
Before: All the lines in table cells were shown on a single line.
Now: The newlines are respected if present in the table cells.

## Notion Test Page ID
https://mango-woodwind-d3c.notion.site/Demo-7a15103d327f4c108a826ffcfd3f8373

