### PR TITLE
Use <p> tag for text blocks

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -405,7 +405,7 @@ export const Block: React.FC<BlockProps> = (props) => {
       const blockColor = block.format?.block_color
 
       return (
-        <div
+        <p
           className={cs(
             'notion-text',
             blockColor && `notion-${blockColor}`,
@@ -416,8 +416,8 @@ export const Block: React.FC<BlockProps> = (props) => {
             <Text value={block.properties.title} block={block} />
           )}
 
-          {children && <div className='notion-text-children'>{children}</div>}
-        </div>
+          {children && <p className='notion-text-children'>{children}</p>}
+        </p>
       )
     }
 


### PR DESCRIPTION
#### Description
Fixes #341

With this PR, the text blocks are rendered as `<p>` tags in the generated HTML instead of a `<div>`.
<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
