### PR TITLE
Add support to new Notion built-in icons

### DIFF
--- a/packages/react-notion-x/src/components/page-icon.tsx
+++ b/packages/react-notion-x/src/components/page-icon.tsx
@@ -29,7 +29,7 @@ export const PageIconImpl: React.FC<{
   hideDefaultIcon = false,
   defaultIcon
 }) => {
-  const { mapImageUrl, recordMap } = useNotionContext()
+  const { mapImageUrl, recordMap, darkMode } = useNotionContext()
   let isImage = false
   let content: any = null
 
@@ -40,6 +40,17 @@ export const PageIconImpl: React.FC<{
     if (icon && isUrl(icon)) {
       const url = mapImageUrl(icon, block)
       isImage = true
+
+      content = (
+        <LazyImage
+          src={url}
+          alt={title || 'page icon'}
+          className={cs(className, 'notion-page-icon')}
+        />
+      )
+    } else if (icon && icon.startsWith('/icons/')) {
+      const url =
+        'http://www.notion.so' + icon + '?mode=' + (darkMode ? 'dark' : 'light')
 
       content = (
         <LazyImage

--- a/packages/react-notion-x/src/components/page-icon.tsx
+++ b/packages/react-notion-x/src/components/page-icon.tsx
@@ -50,7 +50,10 @@ export const PageIconImpl: React.FC<{
       )
     } else if (icon && icon.startsWith('/icons/')) {
       const url =
-        'http://www.notion.so' + icon + '?mode=' + (darkMode ? 'dark' : 'light')
+        'https://www.notion.so' +
+        icon +
+        '?mode=' +
+        (darkMode ? 'dark' : 'light')
 
       content = (
         <LazyImage


### PR DESCRIPTION
#### Description

Added support for the new Notion built-in icons feature!
The icons are served from Notion at this endpoint: `https://www.notion.so/icons/<icon name>?mode=<dark or light>`

#### Notion Test Page ID

[Notion test page with an Icon](https://michaelcasadev.notion.site/Emojis-49f9e212d8cc443791b383f5c87e1d35)