### PR TITLE
Remove additional padding in notion-frame

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -267,6 +267,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
+  padding: 0;
 }
 
 .notion-page-scroller {


### PR DESCRIPTION
#### Description

There is an additional padding of 3px at the top & bottom of the page which is not needed. It's highlighted in green in the picture below

<img width="325" alt="image" src="https://user-images.githubusercontent.com/8146514/187221565-d72e4197-21b9-4902-a1fe-6a4d85fe58e5.png">

#### Notion Test Page ID

The problem is also visible here: https://react-notion-x-demo.transitivebullsh.it/
