### PR TITLE
fixed board views not working with new group by

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-view-board.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-board.tsx
@@ -125,13 +125,13 @@ function Board({ collectionView, collectionData, collection, padding }) {
 
         <div className='notion-board-body'>
           {boardGroups.map((p, index) => {
-            if (!(collectionData as any).board_columns?.results) {
-              return null
-            }
+            const boardResults = (collectionData as any).board_columns?.results
+            if (!boardResults) return null
+            if (!p?.value?.type) return null
 
             const schema = collection.schema[p.property]
             const group = (collectionData as any)[
-              `results:select:${p?.value?.value || 'uncategorized'}`
+              `results:${p?.value?.type}:${p?.value?.value || 'uncategorized'}`
             ]
 
             if (!group || !schema || p.hidden) {


### PR DESCRIPTION
#### Description

Before boards only worked with grouped by "select" type. Notion changed it that you can group by about anything. So the fix is pulling the type that is used for  grouping. The change is backwards compatible as well.

There is currently an issue still where if multiple  views are added in Notion, the board may not appear because the data is with one of the other collectionview types.


Tested on this new  board: f4cd548ded6b42a7a2340d11111ef3be
Tested on this old board also: a899b98b7cdc424585e5ddebbdae60cc

