### PR TITLE
Fixed groupBy board_coumns being added to non board collections query

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -328,9 +328,9 @@ export class NotionAPI {
   ) {
     const type = collectionView?.type
     const isBoardType = type === 'board'
-    const groupBy =
-      collectionView?.format?.board_columns_by ||
-      collectionView?.format?.collection_group_by
+    const groupBy = isBoardType
+      ? collectionView?.format?.board_columns_by
+      : collectionView?.format?.collection_group_by
 
     let filters = []
     if (collectionView.format?.property_filters) {

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -344,6 +344,10 @@ export class NotionAPI {
       })
     }
 
+    if (collectionView?.query2?.filter?.filters) {
+      filters.push(...collectionView.query2.filter.filters)
+    }
+
     let loader: any = {
       type: 'reducer',
       reducers: {


### PR DESCRIPTION
#### Description

Apparently  some collections can have some format data on board_columns_by even  when  they aren't board collelctions. This would mess up the payload for our collection query. and  end  up in retrieving no collection rows.

#### Notion Test Page ID

Found the issue on this page originally.  a0c071336c77426ea9925a5088d92ea0
Tested on 2fea615a97a7401c81be486e4eec2e94  and all the collections from the test workspace to makes sure everything works correctly.
