### PR TITLE
fallback to collection view name if collection name is empty

### DIFF
--- a/packages/react-notion-x/src/third-party/collection.tsx
+++ b/packages/react-notion-x/src/third-party/collection.tsx
@@ -176,7 +176,8 @@ const CollectionViewBlock: React.FC<{
     return null
   }
 
-  const title = getTextContent(collection.name).trim()
+  const title =
+    getTextContent(collection.name).trim() || collectionView.name.trim()
   if (collection.icon) {
     block.format = {
       ...block.format,


### PR DESCRIPTION
#### Description

a collection view is used where the table has no title, because collection has no title

#### Notion Test Page ID

067dd719a912471ea9a3ac10710e7fdf the table doesn't have a title
