### PR TITLE
Add missing optional chaining in getCollectionData function

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -333,7 +333,7 @@ export class NotionAPI {
       : collectionView?.format?.collection_group_by
 
     let filters = []
-    if (collectionView.format?.property_filters) {
+    if (collectionView?.format?.property_filters) {
       filters = collectionView.format?.property_filters.map((filterObj) => {
         //get the inner filter
         return {


### PR DESCRIPTION
#### Description

Since `collectionView` is an optional arg in `getCollectionData()`, calling it without would throw an error because of a missing nullish check.

#### Notion Test Page ID
86b15a89dd4846699383be4476beafa9
