### PR TITLE
allow a links to be used in board and galleries

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-card.tsx
+++ b/packages/react-notion-x/src/third-party/collection-card.tsx
@@ -118,7 +118,6 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
         ...ctx.components,
         // Disable <a> tabs in all child components so we don't create invalid DOM
         // trees with stacked <a> tags.
-        Link: dummyLink,
         PageLink: dummyLink
       }}
     >


### PR DESCRIPTION
#### Description

this adds url  links back into board and gallery collections.  Before the a tags where removed. I believe this was for the concern of a tags being nested. But Notion implements it this way and there doesn't seem to be an issue with the a tags nested.

#### Notion Test Page ID
d2692a6a4a1b420395e4979a2c05c7b4?v=6f12dc69ae7549f985bdbaa5ca81623f
