### PR TITLE
added feature where collection cards can link out to the url property

### DIFF
--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -34,6 +34,7 @@ export interface NotionContext {
   showTableOfContents: boolean
   minTableOfContentsItems: number
   linkTableTitleProperties: boolean
+  isLinkCollectionToUrlProperty: boolean
 
   defaultPageIcon?: string
   defaultPageCover?: string
@@ -61,6 +62,7 @@ export interface PartialNotionContext {
   forceCustomImages?: boolean
   showCollectionViewDropdown?: boolean
   linkTableTitleProperties?: boolean
+  isLinkCollectionToUrlProperty?: boolean
 
   showTableOfContents?: boolean
   minTableOfContentsItems?: number
@@ -161,6 +163,7 @@ const defaultNotionContext: NotionContext = {
   forceCustomImages: false,
   showCollectionViewDropdown: true,
   linkTableTitleProperties: true,
+  isLinkCollectionToUrlProperty: false,
 
   showTableOfContents: false,
   minTableOfContentsItems: 3,

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2792,3 +2792,11 @@ svg.notion-page-icon {
 .notion-collection-view-dropdown-content[data-state='open'] {
   animation-name: slideDownAndFade;
 }
+
+.nested-form-link {
+  background: none!important;
+  border: none;
+  padding: 0!important;
+  text-decoration: underline;
+  cursor: pointer;
+}


### PR DESCRIPTION
#### Description

This is a cool one. added a feature where url properties can become the card link for gallery views and board views. By  default it is not enabled. Have to set `isLinkCollectionToUrlProperty` to true in NotionRenderer to turn it on.
![image](https://user-images.githubusercontent.com/21371266/194420947-03a70582-1da7-41dc-8f5b-6a787fc67eca.png)

Also made a url property  that is visible be a form  subbmision so it can be nested.

#### Notion Test Page ID
d2692a6a4a1b420395e4979a2c05c7b4?v=6f12dc69ae7549f985bdbaa5ca81623f
