### PR TITLE
fixed url properties that may be empty

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-card.tsx
+++ b/packages/react-notion-x/src/third-party/collection-card.tsx
@@ -133,6 +133,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
       .map((p) => {
         return block.properties[p.property]
       })
+      ?.filter((p) => p && p.length > 0 && p[0] != undefined) //case where the url is empty
   }
   let url = null
   if (


### PR DESCRIPTION
#### Description

Issue where url properties are empty and we were accessing a null value.

#### Notion Test Page ID

2ba1d59cc64a4f539a100922a8d312e9
