### PR TITLE
Add Next.js 13 new Image component support

### DIFF
--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -5,7 +5,7 @@ import { ExtendedRecordMap } from 'notion-types'
 import { AssetWrapper } from './components/asset-wrapper'
 import { Checkbox as DefaultCheckbox } from './components/checkbox'
 import { Header } from './components/header'
-import { wrapNextImage, wrapNextLink } from './next'
+import { wrapNextImage, wrapNextLegacyImage, wrapNextLink } from './next'
 import {
   MapImageUrlFn,
   MapPageUrlFn,
@@ -199,8 +199,20 @@ export const NotionContextProvider: React.FC<PartialNotionContext> = ({
     [themeComponents]
   )
 
-  if (wrappedThemeComponents.nextImage) {
+  if (
+    wrappedThemeComponents.nextImage &&
+    wrappedThemeComponents.nextLegacyImage
+  ) {
+    console.warn(
+      'You should not pass both nextImage and nextLegacyImage. Only nextImage component will be used.'
+    )
     wrappedThemeComponents.Image = wrapNextImage(themeComponents.nextImage)
+  } else if (wrappedThemeComponents.nextImage) {
+    wrappedThemeComponents.Image = wrapNextImage(themeComponents.nextImage)
+  } else if (wrappedThemeComponents.nextLegacyImage) {
+    wrappedThemeComponents.Image = wrapNextLegacyImage(
+      themeComponents.nextLegacyImage
+    )
   }
 
   if (wrappedThemeComponents.nextLink) {

--- a/packages/react-notion-x/src/next.tsx
+++ b/packages/react-notion-x/src/next.tsx
@@ -11,6 +11,38 @@ export const wrapNextImage = (NextImage: any): React.FC<any> => {
     height,
 
     className,
+
+    fill,
+
+    ...rest
+  }) {
+    if (fill === 'undefined') {
+      fill = !(width && height)
+    }
+
+    return (
+      <NextImage
+        className={className}
+        src={src}
+        alt={alt}
+        width={!fill && width && height ? width : undefined}
+        height={!fill && width && height ? height : undefined}
+        fill={fill}
+        {...rest}
+      />
+    )
+  }, isEqual)
+}
+
+export const wrapNextLegacyImage = (NextLegacyImage: any): React.FC<any> => {
+  return React.memo(function ReactNotionXNextLegacyImage({
+    src,
+    alt,
+
+    width,
+    height,
+
+    className,
     style,
 
     layout,
@@ -22,7 +54,7 @@ export const wrapNextImage = (NextImage: any): React.FC<any> => {
     }
 
     return (
-      <NextImage
+      <NextLegacyImage
         className={className}
         src={src}
         alt={alt}

--- a/packages/react-notion-x/src/types.ts
+++ b/packages/react-notion-x/src/types.ts
@@ -59,6 +59,7 @@ export interface NotionComponents {
 
   // optional next.js-specific overrides
   nextImage?: any
+  nextLegacyImage?: any
   nextLink?: any
 }
 

--- a/readme.md
+++ b/readme.md
@@ -271,17 +271,17 @@ Another major factor for perf comes from images hosted by Notion. They're genera
 
 `NotionRenderer` also supports lazy image loading with optional low quality image placeholder previews. You can see a demo of this in practice [on this page](https://react-notion-x-demo.transitivebullsh.it/3492bd6dbaf44fe7a5cac62c5d402f06) which is using [lqip-modern](https://github.com/transitive-bullshit/lqip-modern) to pre-generate placeholder images that are inspired by Medium.com's image loading.
 
-If you're using Next.js, we recommend passing `next/image` and `next/link` to the renderer as follows:
+If you're using Next.js, we recommend passing `next/image` or `next/legacy/image`, and `next/link` to the renderer as follows:
 
 ```tsx
-import Image from 'next/image'
+import Image from 'next/image' // or import Image from 'next/legacy/image' if you use legacy Image
 import Link from 'next/link'
 
 export default ({ recordMap }) => (
   <NotionRenderer
     recordMap={recordMap}
     components={{
-      nextImage: Image,
+      nextImage: Image, // or nextLegacyImage: LegacyImage,
       nextLink: Link
     }}
   />
@@ -289,6 +289,8 @@ export default ({ recordMap }) => (
 ```
 
 This wraps these next.js components in a compatability layer so `NotionRenderer` can use them the same as their non-next.js equivalents `<img>` and `<a>`.
+
+Note that custom image component is currently only enabled with preview image or by turning on `forceCustomImages` of `NotionRenderer`.
 
 ## Related
 


### PR DESCRIPTION
#### Description

This PR updates next.js component wrapper to support new Image component from Next.js 13.
The legacy Image component(`next/legacy/image`) will be also supported by changing `nextImage` prop to `nextLegacyImage` prop.
