### PR TITLE
Respect hiding collection view titles if setting is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "NotionX/react-notion-x",
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "license": "MIT",
+  "version": "6.15.8",
   "engines": {
     "node": ">=12"
   },

--- a/packages/notion-types/src/collection.ts
+++ b/packages/notion-types/src/collection.ts
@@ -47,5 +47,6 @@ export interface Collection {
       property: PropertyID
       visibility: 'show' | 'hide'
     }>
+    hide_linked_collection_name?: boolean
   }
 }

--- a/packages/react-notion-x/src/third-party/collection.tsx
+++ b/packages/react-notion-x/src/third-party/collection.tsx
@@ -175,6 +175,8 @@ const CollectionViewBlock: React.FC<{
   }
 
   const title = getTextContent(collection.name).trim()
+  const showTitle =
+    collectionView.format?.hide_linked_collection_name !== true && title
   if (collection.icon) {
     block.format = {
       ...block.format,
@@ -194,9 +196,8 @@ const CollectionViewBlock: React.FC<{
             />
           )}
         </div>
-        <div className='notion-collection-header'>
-          {/*TODO: only show if no full DB*/}
-          {title && (
+        {showTitle && (
+          <div className='notion-collection-header'>
             <div className='notion-collection-header-title'>
               <PageIcon
                 block={block}
@@ -205,8 +206,8 @@ const CollectionViewBlock: React.FC<{
               />
               {title}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
       <div className={cs('notion-collection', className)}>
         <CollectionView


### PR DESCRIPTION
#### Description
In the settings for Collection Views, there's an option to hide the title of the collection.

This PR makes it so that the setting is respected, by looking at the correct field off of `format`.
<img width="617" alt="Screen Shot 2022-11-20 at 4 13 33 PM" src="https://user-images.githubusercontent.com/6259534/202934565-72b81539-4374-4185-9330-faa66640d3bc.png">

(PS: Thank you for building this ❤️)

#### Notion Test Page ID
Collection-View-Title-test-7700cfb836854d229285d85ffd9e913a

### Screenshots
Hidden titles:
<img width="1313" alt="Screen Shot 2022-11-20 at 4 14 02 PM" src="https://user-images.githubusercontent.com/6259534/202934412-a4650d3a-9b68-4f57-b5d5-1c3f2324ebc6.png">

Shown titles:
<img width="1313" alt="Screen Shot 2022-11-20 at 4 13 44 PM" src="https://user-images.githubusercontent.com/6259534/202934416-bd38b3c9-1e88-4da9-9d3a-e80a9482d416.png">

(The other headings are just `<h2>`s :)