### PR TITLE
fix pdf styling

### DIFF
--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -155,6 +155,7 @@ export const Asset: React.FC<{
   } else if (block.type === 'pdf') {
     style.overflow = 'auto'
     style.background = 'rgb(226, 226, 226)'
+    style.display = 'block'
 
     if (!style.padding) {
       style.padding = '8px 16px'


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

The PDF content doesn't display from the first page.Official react-notion demo with pdf doesn't display from the frist page and I can't scroll it to the first page.
![image](https://user-images.githubusercontent.com/71168966/205709140-fb602f93-3065-4616-aff8-f62d14d142fe.png)

It caused by the _display: flex_ at pdf asset, so I change this to _block_.
Solve the issue #411 

#### Notion Test Page ID [Offical demo](https://react-notion-x-demo.transitivebullsh.it/34d650c65da34f888335dbd3ddd141dc)

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
