### PR TITLE
Fix: notion toggle's child Element overflow issue

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1127,6 +1127,7 @@ svg.notion-page-icon {
 }
 
 .notion-toggle {
+  width: 100%;
   padding: 3px 2px;
 }
 .notion-toggle > summary {


### PR DESCRIPTION
#### Description
Hi, I found an issue in Notion Toggle that the child element goes over toggle width when using the nootion link embed. I simply applied the width 100% through the override, and the child element did not overflow, so I'm PRing if it's applicable.

![image](https://user-images.githubusercontent.com/58258782/212653849-18edeb0b-a990-40fe-ab36-8ae5f6583e38.png)

