### PR TITLE
fix: add transliteration module to support non-latin URLs

### DIFF
--- a/packages/notion-utils/package.json
+++ b/packages/notion-utils/package.json
@@ -32,7 +32,8 @@
     "mem": "^9.0.2",
     "normalize-url": "^7.0.3",
     "notion-types": "^6.15.4",
-    "p-queue": "^7.2.0"
+    "p-queue": "^7.2.0",
+    "transliteration": "^2.3.5"
   },
   "ava": {
     "snapshotDir": ".snapshots",

--- a/packages/notion-utils/src/get-canonical-page-id.ts
+++ b/packages/notion-utils/src/get-canonical-page-id.ts
@@ -1,8 +1,8 @@
 import { ExtendedRecordMap } from 'notion-types'
+import { slugify } from 'transliteration'
 
 import { getBlockTitle } from './get-block-title'
 import { getPageProperty } from './get-page-property'
-import { normalizeTitle } from './normalize-title'
 import { uuidToId } from './uuid-to-id'
 
 /**
@@ -22,7 +22,7 @@ export const getCanonicalPageId = (
     const slug =
       (getPageProperty('slug', block, recordMap) as string | null) ||
       (getPageProperty('Slug', block, recordMap) as string | null) ||
-      normalizeTitle(getBlockTitle(block, recordMap))
+      slugify(getBlockTitle(block, recordMap))
 
     if (slug) {
       if (uuid) {


### PR DESCRIPTION
## Problem: getCanonicalPageId does not support non-latin page titles

### Issue:

I am using [[Notion.so](http://notion.so/)](http://Notion.so) to run [[FinUA.org](http://finua.org/)](http://FinUA.org) website and currently it isb deployed with [[super.so](http://super.so/)](http://super.so). I have been using nextjs-notion-starter-kit project for it (thank you). 

As deployed the project to Vercel, I realized that there were quite a few browser warnings about the page due to generated page URLs (they looked broken). 
<img width="925" alt="Screenshot 2023-01-21 at 18 41 25" src="https://user-images.githubusercontent.com/7344718/213877278-1b49e3e9-658f-4b5e-a5ad-f55279cf597f.png">

the page behind it:
<img width="878" alt="Screenshot 2023-01-21 at 18 41 37" src="https://user-images.githubusercontent.com/7344718/213877289-a1bfe8cb-518e-4b8e-86fd-3b26175f57c4.png">

moreover, this page also had the same URL generated `/-` despite being a separate page, and clicking on it would lead to the first page.

<img width="921" alt="Screenshot 2023-01-21 at 18 42 13" src="https://user-images.githubusercontent.com/7344718/213877325-ae7c2adf-578b-42ac-84a4-ae6abe2eb840.png">


I have investigated it, and it seems that the problem was in the module [https://github.com/transitive-bullshit/nextjs-notion-starter-kit/blob/main/lib/get-canonical-page-id.ts](https://github.com/transitive-bullshit/nextjs-notion-starter-kit/blob/main/lib/get-canonical-page-id.ts) 

```jsx
import { ExtendedRecordMap } from 'notion-types'
import {
  getCanonicalPageId as getCanonicalPageIdImpl,
  parsePageId
} from 'notion-utils'

import { inversePageUrlOverrides } from './config'

export function getCanonicalPageId(
  pageId: string,
  recordMap: ExtendedRecordMap,
  { uuid = true }: { uuid?: boolean } = {}
): string | null {
  const cleanPageId = parsePageId(pageId, { uuid: false })
  if (!cleanPageId) {
    return null
  }

  const override = inversePageUrlOverrides[cleanPageId]
  if (override) {
    return override
  } else {
		// PROBLEM: this line seemed to be the issue
    return getCanonicalPageIdImpl(pageId, recordMap, {
      uuid
    })
  }
}
```

I went to the module [https://github.com/NotionX/react-notion-x/tree/master/packages/notion-utils](https://github.com/NotionX/react-notion-x/tree/master/packages/notion-utils) 

and copied [https://github.com/NotionX/react-notion-x/blob/master/packages/notion-utils/src/get-canonical-page-id.ts](https://github.com/NotionX/react-notion-x/blob/master/packages/notion-utils/src/get-canonical-page-id.ts) module, the problem seemed to be `getCanonicalPageId` function, it only seemed to work for Latin symbols `normalizeTitle(getBlockTitle(block, recordMap))`:

I pulled the `normalizeTitle` function, and yes, it seems to be the case

```jsx
function normalizeTitle(title) {
  return (title || '')
    .replace(/ /g, '-')
    .replace(/[^a-zA-Z0-9-\u4e00-\u9fa5]/g, '')
    .replace(/--/g, '-')
    .replace(/-$/, '')
    .replace(/^-/, '')
    .trim()
    .toLowerCase()
}

const eng = normalizeTitle('Naapurin Maalaiskana (NMK), in Lieto, in Turku area');
const ukr = normalizeTitle('Робота помічника з обслуговування контейнерів');
const ukr1 = normalizeTitle('Ищем литейщиков в Карккила, Финляндия, для обработки изделий в металлургической промышленности');
console.log('test', eng, ukr, ukr1)

// "test"
// "naapurin-maalaiskana-nmk-in-lieto-in-turku-area"
// ""
// "---"
```

### Solution:

The one that worked for me was just replacing `normalizeTitle(getBlockTitle(block, recordMap))` with `slugify` from the transliteration npm package.

#### Notion Test Page ID
`701245d6db8c413689d180e87269ee56`