### PR TITLE
Hot fix -  new image src with file.notion.so not working

### DIFF
--- a/packages/notion-utils/src/get-page-image-urls.ts
+++ b/packages/notion-utils/src/get-page-image-urls.ts
@@ -23,7 +23,10 @@ export const getPageImageUrls = (
       if (block) {
         if (block.type === 'image') {
           const signedUrl = recordMap.signed_urls?.[block.id]
-          const source = signedUrl || block.properties?.source?.[0]?.[0]
+          let source = signedUrl || block.properties?.source?.[0]?.[0]
+          if (source.includes('file.notion.so')) {
+            source = block.properties?.source?.[0]?.[0]
+          }
 
           if (source) {
             images.push({

--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -124,7 +124,7 @@ export const Asset: React.FC<{
     }
   }
 
-  const source =
+  let source =
     recordMap.signed_urls?.[block.id] || block.properties?.source?.[0]?.[0]
   let content = null
 
@@ -258,7 +258,10 @@ export const Asset: React.FC<{
     }
   } else if (block.type === 'image') {
     // console.log('image', block)
-
+    //kind of a hack for now. New file.notion.so images aren't signed correctly
+    if (source.includes('file.notion.so')) {
+      source = block.properties?.source?.[0]?.[0]
+    }
     const src = mapImageUrl(source, block as Block)
     const caption = getTextContent(block.properties?.caption)
     const alt = caption || 'notion image'


### PR DESCRIPTION
#### Description

Notion made a change where some pages use file.notion.so as their signed urls.
These srcs aren't working currently.
This is a hot fix to at least get it working.
Using the block image src instead just in this case.

#### Notion Test Page ID
d9cc0ffee90e41c4b3ab1f450c346ba7
Don't have a ton of examples to play around with because my Notion workspace isn't producing the file.notion.so srcs. 😅
