### PR TITLE
feat: support for normalize japanese hiragana and katakana title

### DIFF
--- a/packages/notion-utils/src/normalize-title.ts
+++ b/packages/notion-utils/src/normalize-title.ts
@@ -1,7 +1,7 @@
 export const normalizeTitle = (title?: string | null): string => {
   return (title || '')
     .replace(/ /g, '-')
-    .replace(/[^a-zA-Z0-9-\u4e00-\u9fa5]/g, '')
+    .replace(/[^a-zA-Z0-9-\u4e00-\u9FFF\u3041-\u3096\u30A1-\u30FC\u3000-\u303F]/g, '')
     .replace(/--/g, '-')
     .replace(/-$/, '')
     .replace(/^-/, '')


### PR DESCRIPTION
#### Description

I love using react-notion-x on my blog. Thanks again. 
I would like to add Japanese hiragana and katakana to solve the problem similar to #176.

Japanese is written in a mixture of kanji, hiragana and katakana. 
Example: https://jsfiddle.net/uw5m9kts/6/

In [RFC-1738](https://www.ietf.org/rfc/rfc1738.txt), It basically supports us-ascii sets, browsers will encode japanese charaters automatically too.