### PR TITLE
fix: set table row background color

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -786,13 +786,14 @@ export const Block: React.FC<BlockProps> = (props) => {
         ?.value as types.TableBlock
       const order = tableBlock.format?.table_block_column_order
       const formatMap = tableBlock.format?.table_block_column_format
+      const backgroundColor = block.format?.block_color
 
       if (!tableBlock || !order) {
         return null
       }
 
       return (
-        <tr className={cs('notion-simple-table-row', blockId)}>
+        <tr className={cs('notion-simple-table-row', backgroundColor && `notion-${backgroundColor}`, blockId)}>
           {order.map((column) => {
             const color = formatMap?.[column]?.color
 


### PR DESCRIPTION
#### Description

You can set table row background color in Notion, but it's not reflected in React Notion X

<img width="329" alt="CleanShot 2023-02-11 at 22 54 25@2x" src="https://user-images.githubusercontent.com/8784712/218265274-39efc957-e19d-4207-ad2f-975b4ea96e8f.png">


#### Notion Test Page ID

https://egoist.notion.site/react-notion-x-patch-1-2843d872184a419a9dde2ba1ad1a64db
