### PR TITLE
Make the paddings of list blocks aligned with Notion style

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -443,14 +443,14 @@ export const Block: React.FC<BlockProps> = (props) => {
 
       if (block.content) {
         output = (
-          <>
-            {block.properties && (
-              <li>
+          <li>
+            <span>
+              {block.properties && (
                 <Text value={block.properties.title} block={block} />
-              </li>
-            )}
+              )}
+            </span>
             {wrapList(children)}
-          </>
+          </li>
         )
       } else {
         output = block.properties ? (

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -766,17 +766,16 @@ svg.notion-page-icon {
   margin: 0;
   margin-block-start: 0.6em;
   margin-block-end: 0.6em;
+  padding-inline-start: 28px;
 }
 
 .notion-list-disc {
   list-style-type: disc;
-  padding-inline-start: 1.7em;
   margin-top: 0;
   margin-bottom: 0;
 }
 .notion-list-numbered {
   list-style-type: decimal;
-  padding-inline-start: 1.6em;
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -790,8 +789,17 @@ svg.notion-page-icon {
 }
 
 .notion-list li {
-  padding: 6px 0;
+  padding: 6px 2px;
   white-space: pre-wrap;
+}
+
+.notion-list li > .notion-list {
+  padding-inline-start: 26px;
+}
+
+.notion-list li > .notion-list > :not(li) {
+  margin-left: -28px;
+  width: calc(100% + 28px);
 }
 
 .notion-asset-wrapper {
@@ -1128,14 +1136,14 @@ svg.notion-page-icon {
 
 .notion-toggle {
   width: 100%;
-  padding: 3px 2px;
+  padding: 3px 2px 3px 28px;
 }
 .notion-toggle > summary {
+  list-style-position: outside;
+  padding-left: 2px;
+  padding-right: 2px;
   cursor: pointer;
   outline: none;
-}
-.notion-toggle > div {
-  margin-left: 1.1em;
 }
 
 .notion-collection {
@@ -1398,8 +1406,9 @@ svg.notion-page-icon {
 }
 
 .notion-property-checkbox {
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  display: flex;
+  justify-content: center;
 }
 
 .notion-property-checkbox-checked {
@@ -1769,7 +1778,7 @@ svg.notion-page-icon {
 }
 
 .notion-to-do-children {
-  padding-left: 1.5em;
+  padding-left: 28px;
 }
 
 .notion-to-do-checked .notion-to-do-item {
@@ -1778,12 +1787,14 @@ svg.notion-page-icon {
 }
 
 .notion-to-do-body {
+  padding-left: 2px;
+  padding-right: 2px;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 .notion-to-do-item .notion-property-checkbox {
-  margin-right: 8px;
+  margin-right: 2px;
 }
 
 .notion-google-drive {


### PR DESCRIPTION
#### Description

In Notion, different list blocks of the same indent level have their titles (list item names) started from the same horizontal position. This PR attempts to implement this style in react-notion-x.

* **Notion**
  ![CleanShot 2023-03-19 at 15 46 55](https://user-images.githubusercontent.com/7194254/226161263-349fd174-58b7-4401-96a4-da847013b36f.png)
* **react-notion-x**
  ![CleanShot 2023-03-19 at 15 48 23](https://user-images.githubusercontent.com/7194254/226161310-d5b5dcc0-9943-40b3-ad56-f816f4b0406e.png)

#### Notion Test Page ID

`a5126a5fc56341b7abde5a871ab8c95e`
