### PR TITLE
handle possible NotionCompatAPI without search

### DIFF
--- a/examples/full/lib/notion.ts
+++ b/examples/full/lib/notion.ts
@@ -28,5 +28,11 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
 }
 
 export async function search(params: SearchParams): Promise<SearchResults> {
-  return notion.search(params)
+  if (notion instanceof NotionAPI) {
+    return notion.search(params)
+  } else {
+    console.error(
+      'NotionCompatAPI does not have a search method. Use NotionAPI instead.'
+    )
+  }
 }


### PR DESCRIPTION
#### Description
Only NotionAPI has the `search` method. However, the `notion` variable can also be of type `NotionCompatAPI`.
This PR introduces better handling for that error and it also makes typescript happy. 
