### PR TITLE
bugfix: missing plugin declaration in .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -16,5 +16,6 @@
   ],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
-  "importOrderGroupNamespaceSpecifiers": true
+  "importOrderGroupNamespaceSpecifiers": true,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"]
 }


### PR DESCRIPTION
#### Description

Prettier `plugins` was missing in `.prettierrc`. The symthom was a lot of "unkwnon" configurations from `"@trivago/prettier-plugin-sort-imports"`.

Adding it to `.prettierrc` fixed the issue.