### PR TITLE
feat(notion-client): support notion internal integration token(secret)

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -17,23 +17,27 @@ import * as types from './types'
 export class NotionAPI {
   private readonly _apiBaseUrl: string
   private readonly _authToken?: string
+  private readonly _secret?: string
   private readonly _activeUser?: string
   private readonly _userTimeZone: string
 
   constructor({
     apiBaseUrl = 'https://www.notion.so/api/v3',
     authToken,
+    secret,
     activeUser,
     userTimeZone = 'America/New_York'
   }: {
     apiBaseUrl?: string
     authToken?: string
+    secret?: string
     userLocale?: string
     userTimeZone?: string
     activeUser?: string
   } = {}) {
     this._apiBaseUrl = apiBaseUrl
     this._authToken = authToken
+    this._secret = secret
     this._activeUser = activeUser
     this._userTimeZone = userTimeZone
   }
@@ -592,6 +596,9 @@ export class NotionAPI {
 
     if (this._authToken) {
       headers.cookie = `token_v2=${this._authToken}`
+    }
+    if (this._secret) {
+      headers.authorization = `Bearer ${this._secret}`
     }
 
     if (this._activeUser) {


### PR DESCRIPTION
#### Description
👏 Support using `notion internal integration token`

If I don't want my notion page to be shared, but I still want to get it. 
in the current version, i can use `authToken` in the request cookie, but the `authToken` has a maximum expiration time of 180 days.
In fact, there is another way, which is to use `notion internal integration token`
in [my-integrations](https://www.notion.so/my-integrations) page, I can generate a `internal integration token`, and then use it in the request header.
so, i copyed [@notionhq/client](https://github1s.com/makenotion/notion-sdk-js/blob/HEAD/src/Client.ts)'s code to `notion-client`
```TypeScript
private authAsHeaders(auth?: string): Record<string, string> {
  const headers: Record<string, string> = {}
  const authHeaderValue = auth ?? this.#auth
  if (authHeaderValue !== undefined) {
    headers["authorization"] = `Bearer ${authHeaderValue}`
  }
  return headers
}
```

#### Notion Test Page ID
notion page id is not needed here
