### PR TITLE
fix: show reminder date and time

### DIFF
--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -191,6 +191,12 @@ export const Text: React.FC<{
                   const startDate = v.start_date
 
                   return formatDate(startDate)
+                } else if (type === 'datetime') {
+                  // Example: Jul 31, 2010 20:00
+                  const startDate = v.start_date
+                  const startTime = v.start_time
+
+                  return `${formatDate(startDate)} ${startTime}`
                 } else if (type === 'daterange') {
                   // Example: Jul 31, 2010 → Jul 31, 2020
                   const startDate = v.start_date


### PR DESCRIPTION
#### Description

Show date and time for reminders.

Before

<img width="835" alt="Screenshot 2023-04-19 at 19 33 24" src="https://user-images.githubusercontent.com/1460910/233214442-4226bd20-fdcd-49c5-8f0f-28dd3df9f7a1.png">

After

<img width="835" alt="Screenshot 2023-04-19 at 19 33 17" src="https://user-images.githubusercontent.com/1460910/233214345-5a643aeb-fdab-44bf-93c3-05168a04634c.png">

#### Notion Test Page ID

5a441e784a104ed685dcad91cb975c16
