### PR TITLE
fix: empty group title for board view

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1734,7 +1734,7 @@ svg.notion-page-icon {
 }
 
 .notion-board-th-empty {
-  margin-right: 4px;
+  margin-right: 6px;
   position: relative;
   top: 2px;
 }

--- a/packages/react-notion-x/src/third-party/collection-view-board.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-board.tsx
@@ -66,8 +66,6 @@ function Board({ collectionView, collectionData, collection, padding }) {
     collectionView?.format?.board_groups2 ||
     []
 
-  const boardGroupBy = collectionView?.format?.board_columns_by?.groupBy
-
   const boardStyle = React.useMemo(
     () => ({
       paddingLeft: padding
@@ -106,18 +104,13 @@ function Board({ collectionView, collectionData, collection, padding }) {
                     {group.value?.value ? (
                       <Property
                         schema={schema}
-                        data={[
-                          [
-                            group.value?.value[boardGroupBy] ||
-                              group.value?.value
-                          ]
-                        ]}
+                        data={[[group.value?.value]]}
                         collection={collection}
                       />
                     ) : (
                       <span>
                         <EmptyIcon className='notion-board-th-empty' />
-                        {`No ${schema.name}` || 'No Select'}
+                        {schema?.name ? `No ${schema.name}` : 'No Select'}
                       </span>
                     )}
 

--- a/packages/react-notion-x/src/third-party/collection-view-board.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-board.tsx
@@ -116,8 +116,8 @@ function Board({ collectionView, collectionData, collection, padding }) {
                       />
                     ) : (
                       <span>
-                        <EmptyIcon className='notion-board-th-empty' /> No
-                        Select
+                        <EmptyIcon className='notion-board-th-empty' />
+                        {`No ${schema.name}` || 'No Select'}
                       </span>
                     )}
 

--- a/packages/react-notion-x/src/third-party/collection-view-board.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-board.tsx
@@ -66,6 +66,8 @@ function Board({ collectionView, collectionData, collection, padding }) {
     collectionView?.format?.board_groups2 ||
     []
 
+  const boardGroupBy = collectionView?.format?.board_columns_by?.groupBy
+
   const boardStyle = React.useMemo(
     () => ({
       paddingLeft: padding
@@ -104,7 +106,12 @@ function Board({ collectionView, collectionData, collection, padding }) {
                     {group.value?.value ? (
                       <Property
                         schema={schema}
-                        data={[[group.value?.value]]}
+                        data={[
+                          [
+                            group.value?.value[boardGroupBy] ||
+                              group.value?.value
+                          ]
+                        ]}
                         collection={collection}
                       />
                     ) : (


### PR DESCRIPTION
#### Description

Fix title for empty group on board view, using the property name instead of a static title.

#### Example

Board view grouped by **Priority** property:

Before
<img width="1080" alt="Screenshot 2023-04-29 at 19 56 03" src="https://user-images.githubusercontent.com/1460910/235327371-be47c7bf-c56b-4916-8739-272440f9826a.png">

After
<img width="1080" alt="Screenshot 2023-04-29 at 19 55 43" src="https://user-images.githubusercontent.com/1460910/235327374-5ee48209-988c-4b94-832e-1c82b34622d7.png">

#### Notion Test Page ID

`16f256fbf9b54bc6b4befe13ba74faeb`
