### PR TITLE
fix: the notion-external-mention svg icon is displayed abnormally on Safari

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2623,6 +2623,11 @@ svg.notion-page-icon {
   margin-right: 0.3em;
 }
 
+.notion-external-mention .notion-external-image svg {
+  width: 100%;
+  height: 100%;
+}
+
 .notion-external-description {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION

#### Description

Fix the problem that the notion-external-mention svg icon is displayed abnormally on Safari

current:

<img width="519" alt="image" src="https://github.com/NotionX/react-notion-x/assets/19328403/1b8c1440-0612-4454-baf3-fdd7a071ce12">

after fixed:

<img width="389" alt="image" src="https://github.com/NotionX/react-notion-x/assets/19328403/69f98328-c79a-4281-84f8-a6c351652b66">

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

https://react-notion-x-demo.transitivebullsh.it

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
