### PR TITLE
hotfix / remove log

### DIFF
--- a/packages/notion-compat/src/notion-compat-api.ts
+++ b/packages/notion-compat/src/notion-compat-api.ts
@@ -200,7 +200,6 @@ export class NotionCompatAPI {
     let cursor: string
 
     do {
-      console.log('blocks.children.list', { blockId, cursor })
       const res = await this.client.blocks.children.list({
         block_id: blockId,
         start_cursor: cursor


### PR DESCRIPTION
@transitive-bullshit Can we get rid of this console.log() please, it clutters the logs.

Also, no TS types are available for `"notion-compat": "^6.16.0",` version.
There is also no `@types/notion-compat`, so TS complains when importing it, and I have to ts-expect-error.

<img width="983" alt="image" src="https://github.com/NotionX/react-notion-x/assets/63292629/e00205b7-107f-4668-9bcd-c4ca02c38c7a">

