### PR TITLE
Add Mermaid Support to Code Block Rendering

### DIFF
--- a/packages/react-notion-x/package.json
+++ b/packages/react-notion-x/package.json
@@ -25,6 +25,7 @@
     "@fisch0920/medium-zoom": "^1.0.7",
     "@matejmazur/react-katex": "^3.1.3",
     "katex": "^0.15.3",
+    "mermaid": "^10.2.3",
     "notion-types": "^6.16.0",
     "notion-utils": "^6.16.0",
     "prismjs": "^1.27.0",

--- a/packages/react-notion-x/src/third-party/code.tsx
+++ b/packages/react-notion-x/src/third-party/code.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import copyToClipboard from 'clipboard-copy'
+import mermaid from 'mermaid'
 import { CodeBlock } from 'notion-types'
 import { getBlockTitle } from 'notion-utils'
 import { highlightElement } from 'prismjs'
@@ -43,6 +44,33 @@ export const Code: React.FC<{
       }
     }
   }, [codeRef])
+
+  React.useEffect(() => {
+    const renderMermaid = async () => {
+      try {
+        if (language === 'mermaid') {
+          mermaid.initialize({
+            startOnLoad: true,
+            theme: 'dark',
+            flowchart: {
+              useMaxWidth: false,
+              htmlLabels: true,
+              curve: 'linear'
+            }
+          })
+          await mermaid.run({ querySelector: 'code.language-mermaid' })
+          document.querySelectorAll('code.language-mermaid').forEach((el) => {
+            el.parentElement.style.display = 'flex'
+            el.parentElement.style.justifyContent = 'center'
+          })
+        }
+      } catch (err) {
+        console.warn('mermaid highlight error', err)
+      }
+    }
+
+    renderMermaid()
+  }, [language])
 
   const onClickCopyToClipboard = React.useCallback(() => {
     copyToClipboard(content)

--- a/packages/react-notion-x/src/third-party/code.tsx
+++ b/packages/react-notion-x/src/third-party/code.tsx
@@ -59,10 +59,6 @@ export const Code: React.FC<{
             }
           })
           await mermaid.run({ querySelector: 'code.language-mermaid' })
-          document.querySelectorAll('code.language-mermaid').forEach((el) => {
-            el.parentElement.style.display = 'flex'
-            el.parentElement.style.justifyContent = 'center'
-          })
         }
       } catch (err) {
         console.warn('mermaid highlight error', err)


### PR DESCRIPTION
#### Description

This pull request introduces support for rendering Mermaid.js diagrams in code blocks. This feature is implemented using the Mermaid.js library and is activated whenever a code block with the class `language-mermaid` is encountered.

Here are some examples of Mermaid.js diagrams rendered using this implementation:

[![Fire-Shot-Capture-001-Test-mermaid-react-notion-x-localhost.png](https://i.postimg.cc/DZnKjqvv/Fire-Shot-Capture-001-Test-mermaid-react-notion-x-localhost.png)](https://postimg.cc/Y4nVjLLZ)


#### Notion Test Page ID
e970087274df44338c5795713e62e61e

This feature would be a valuable addition to the react-notion-x library, as it would allow users to include rich, interactive diagrams in their Notion pages using the popular Mermaid.js syntax.