### PR TITLE
Fix broken search function

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -549,7 +549,9 @@ export class NotionAPI {
       type: 'BlocksInAncestor',
       source: 'quick_find_public',
       ancestorId: parsePageId(params.ancestorId),
-      sort: 'Relevance',
+      sort: {
+        field: 'relevance'
+      },
       limit: params.limit || 20,
       query: params.query,
       filters: {


### PR DESCRIPTION
#### Description
**Problem:** The search function is currently broken: we get a mysterious 405 error when we prop open the dev console and inspect the search request:
<img src="https://i.imgur.com/AygfPLw.png" alt="An image showing https://transitivebullsh.it with a failed POST request to the search api route, with a status code of 405" />

It turns out that Notion slightly changed the API for search, resulting in the way the library `notion-client` sends the API request to Notion for searching to be broken and throw an error:
<img src="https://i.imgur.com/wUPZr3z.png" alt="An image of Postman showing the result of the API request sent to Notion to search by notion-client" />
*The request body in the above screenshot was generated by `notion-client` and I just put it in Postman to show the error that is thrown by the Notion API.*


Luckily this was a quick fix! I went to Notion and performed a search and inspected how they sent the API request, and noticed a slight difference:
<img src="https://i.imgur.com/qsbCKr1.png" alt="An image showing an API request to the Notion search API route by the Notion web app, which reveals a difference in the way the sort key is sent" />
For the `sort` key, `notion-client` currently sends the following:
```json
"sort": "Relevance"
```
While the Notion web app sends:
```json
"sort": {
    "field": "relevance"
}
```

So I changed `notion-client` to send the `sort` the same way the Notion web app sends it (which you can see in the code of this pull request) and the search function started working again!
<img src="https://i.imgur.com/L9TslOE.png" alt="The search function working again!" />
<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID
`cebbcc4b7b784d63819ef7db02054b49`

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
