### PR TITLE
fix: Fix collection list view hydration (remove invalid <a> tag nesting)

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -11,6 +11,8 @@
   --fg-color-5: rgba(55, 53, 47, 0.024);
   --fg-color-6: rgba(55, 53, 47, 0.8);
   --fg-color-icon: var(--fg-color);
+  --fg-color-underline: rgba(55, 53, 47, 0.28);
+  --fg-color-underline-hover: var(--fg-color-6);
 
   --bg-color: #fff;
   --bg-color-0: rgba(135, 131, 120, 0.15);
@@ -86,6 +88,7 @@
 
   --notion-max-width: 720px;
   --notion-header-height: 45px;
+  --notion-link-underline-thickness: 0.05em;
 }
 
 .dark-mode {
@@ -752,15 +755,13 @@ svg.notion-page-icon {
   color: inherit;
   word-break: break-word;
   text-decoration: inherit;
-  border-bottom: 0.05em solid;
-  border-color: var(--fg-color-2);
-  opacity: 0.7;
-  transition: border-color 100ms ease-in, opacity 100ms ease-in;
+  border-bottom: var(--notion-link-underline-thickness) solid;
+  border-color: var(--fg-color-underline);
+  transition: border-color 100ms ease-in;
 }
 
 .notion-link:hover {
-  border-color: var(--fg-color-6);
-  opacity: 1;
+  border-color: var(--fg-color-underline-hover);
 }
 
 .notion-collection .notion-link {
@@ -1646,6 +1647,13 @@ svg.notion-page-icon {
   text-overflow: ellipsis;
   font-weight: 500;
   line-height: 1.3;
+  text-decoration: underline;
+  text-decoration-color: var(--fg-color-underline);
+  text-decoration-thickness: var(--notion-link-underline-thickness);
+}
+
+.notion-list-item-title:hover {
+  border-color: var(--fg-color-underline-hover);
 }
 
 .notion-list-item-body {
@@ -2721,7 +2729,7 @@ svg.notion-page-icon {
 .notion-external-mention .notion-external-title {
   display: inline;
   font-size: 16px;
-  border-bottom: 0.05em solid var(--fg-color-1);
+  border-bottom: var(--notion-link-underline-thickness) solid var(--fg-color-1);
 }
 
 .notion-external-subtitle {

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1664,8 +1664,8 @@ svg.notion-page-icon {
 }
 
 .notion-list-item-property {
-  /* display: flex;
-  align-items: center; */
+  display: flex;
+  align-items: center;
   margin-left: 14px;
   font-size: 14px;
 }
@@ -2749,7 +2749,7 @@ svg.notion-page-icon {
   box-shadow: rgba(15, 15, 15, 0.1) 0 0 0 1px, rgba(15, 15, 15, 0.1) 0 2px 4px;
 }
 
-.notion-external-mention .notion-external-subtitle-item{
+.notion-external-mention .notion-external-subtitle-item {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
@@ -2758,37 +2758,36 @@ svg.notion-page-icon {
   padding: 4px 0;
 }
 
-.notion-external-mention .notion-external-subtitle-item-name{
+.notion-external-mention .notion-external-subtitle-item-name {
   flex: none;
   width: 70px;
   font-weight: 500;
 }
 
-.notion-external-mention .notion-external-subtitle-item-desc{
-  flex: 1
+.notion-external-mention .notion-external-subtitle-item-desc {
+  flex: 1;
 }
 
 .notion-external-description:hover .notion-external-subtitle {
   display: block;
 }
 
-.notion-preview-card-domain-warp{
+.notion-preview-card-domain-warp {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
 }
 
-.notion-preview-card-domain-warp .notion-preview-card-domain{
-padding-left: 4px;
-
+.notion-preview-card-domain-warp .notion-preview-card-domain {
+  padding-left: 4px;
 }
-.notion-preview-card-domain-warp .notion-preview-card-logo{
+.notion-preview-card-domain-warp .notion-preview-card-logo {
   width: 14px;
   height: 14px;
 }
 
-.notion-preview-card-title{
+.notion-preview-card-title {
   font-size: 16px;
   line-height: 1.5;
   padding: 4px 0;
@@ -2891,7 +2890,7 @@ padding-left: 4px;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  width: 120%
+  width: 120%;
 }
 
 .notion-collection-view-tabs-content-item {
@@ -2941,9 +2940,9 @@ padding-left: 4px;
 }
 
 .nested-form-link {
-  background: none!important;
+  background: none !important;
   border: none;
-  padding: 0!important;
+  padding: 0 !important;
   text-decoration: underline;
   cursor: pointer;
 }

--- a/packages/react-notion-x/src/third-party/collection-view-list.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-list.tsx
@@ -69,6 +69,7 @@ function List({ blockIds, collection, collectionView }) {
                     data={titleData}
                     block={block}
                     collection={collection}
+                    linkToTitlePage={false}
                   />
                 </div>
 


### PR DESCRIPTION
#### Description

`react-notion-x`, when rendering a `CollectionViewList` row, in the `Collection` component, nests two `<a>` tags within each other, which is invalid HTML (fixes #492). 

<img width="543" alt="Screenshot 2023-07-09 at 1 34 18 PM" src="https://github.com/NotionX/react-notion-x/assets/635300/083a4e4e-4ec9-4463-8001-dc9362e04624">



When used with a next.js project, this causes a hydration error (fixes #410).

<img width="1624" alt="Screenshot 2023-07-09 at 1 33 15 PM" src="https://github.com/NotionX/react-notion-x/assets/635300/c7fd4d06-ca13-494f-89e4-f889ac830570">



This PR makes the following changes to fix this:
* `linkToTitlePage` on the `Property` component used in a `CollectionViewList` is set to `false` to prevent a nested `<a>` tag in the row's root element.
* With the non-nesting occurring, `.notion-list-item-title` is updated to have a `text-decoration: underline` to match `.notion-link`. Some new CSS variables are added to support this.
* `.notion-list-item-property` is updated to vertically align it's content, as it is in Notion.
* Some CSS formatting is fixed.

#### Notion Test Page ID

Test idea for a page with a Collection List View is here: `0260a95744a64f4ca67456420761be24`
