### PR TITLE
fix: the eoi component displays an exception under the block type

### DIFF
--- a/packages/react-notion-x/src/components/eoi.tsx
+++ b/packages/react-notion-x/src/components/eoi.tsx
@@ -63,8 +63,14 @@ export const EOI: React.FC<{
 
       <div className='notion-external-description'>
         <div className='notion-external-title'>{title}</div>
-
-        {(owner || lastUpdated) && (
+        {!inline && owner ? (
+          <div className='notion-external-block-desc'>
+            {owner}
+            {lastUpdated && <span> • </span>}
+            {lastUpdated && `Updated ${lastUpdated}`}
+          </div>
+        ) : null}
+        {inline && (owner || lastUpdated) && (
           <MentionPreviewCard
             title={title}
             owner={owner}

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2729,6 +2729,13 @@ svg.notion-page-icon {
   color: var(--fg-color-3);
 }
 
+.notion-external-block-desc {
+  color: rgba(55, 53, 47, 0.65);
+  font-size: 12px;
+  white-space: nowrap;
+  padding-top: 4px;
+}
+
 .notion-external-mention .notion-external-subtitle {
   display: none;
   position: absolute;


### PR DESCRIPTION
(cherry picked from commit 6c990033c7a8d82a816121b7d8fc82dcd076cfa5)

#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->
fix  the eoi component displays an exception under the block type

error ui:
<img width="890" alt="image" src="https://github.com/NotionX/react-notion-x/assets/19328403/dbec5622-78e6-4aa4-956e-0106f447be9d">

correct ui
<img width="787" alt="image" src="https://github.com/NotionX/react-notion-x/assets/19328403/32bed641-f337-4e7a-a04e-9e3d35f6566f">


#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
