### PR TITLE
fix: h tag not being new line when using multiple h tags in a row

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -481,7 +481,7 @@
 
 .notion-h {
   position: relative;
-  display: inline-block;
+  display: block;
 
   font-weight: 600;
   line-height: 1.3;


### PR DESCRIPTION
## Description

### Bug
I think there is a bug with showing multiple h tags in a row.

It looks like below.
<img width="687" alt="Screenshot 2023-09-20 at 10 50 17" src="https://github.com/NotionX/react-notion-x/assets/90785316/6e047a98-5c46-47b3-9f56-d06dcf65854e">

### How to fix this problem
there is a css file in react-notion-x/src/styles.css

and i changed `display: inline-block;` to `display: block;`
<img width="223" alt="Screenshot 2023-09-20 at 10 56 04" src="https://github.com/NotionX/react-notion-x/assets/90785316/bc740bd7-a8d6-43cc-9b4d-2d658f0a9725">

#### After Fix
<img width="677" alt="Screenshot 2023-09-20 at 11 00 43" src="https://github.com/NotionX/react-notion-x/assets/90785316/871c5d2b-f167-4d58-9431-381e16e226b7">

## Notion Test Page ID

### My Tech Blog which has the problem
[LINK](https://chachablog.vercel.app/모든-개발자를-위한-http-웹-기본-지식)

### My Notion Page linked with this blog page
[LINK](https://cha3088.notion.site/HTTP-0290042ed5fc4c05b9bc47d5bc531ca1?pvs=4)