### PR TITLE
Fix: fixed toggle issue

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -481,7 +481,7 @@
 
 .notion-h {
   position: relative;
-  display: inline-block;
+  display: inline;
 
   font-weight: 600;
   line-height: 1.3;


### PR DESCRIPTION
@transitive-bullshit @normdoow  This is pr for issue #513.

<img height="400" alt="fixed toggle issue" src="https://github.com/NotionX/react-notion-x/assets/105717406/fabcdb57-0cb6-4af2-ad47-1df3b59c6808"/>


/react-notion-x/packages/react-notion-x/src/styles.css

`.notion-h {
  display: inline-block;
}`

Changed the code above as below:

`.notion-h {
  display: inline;
}`

