### PR TITLE
fix: add missing table_block_row_header to TableBlock type

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -445,6 +445,7 @@ export interface TableBlock extends BaseBlock {
       [column: string]: { width?: number; color?: Color }
     }
     table_block_column_header: boolean
+    table_block_row_header: boolean
     table_block_column_order: string[]
   }
   view_ids: ID[]


### PR DESCRIPTION
#### Description

Add missing table_block_row_header to TableBlock type.
When setting the first row of the table as the header, the table block has this field.

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
