### PR TITLE
Add Github Action workflow to publish releases automatically to NPM registry. Fixes #537

### DIFF
--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -1,0 +1,22 @@
+# Publishes a package to npmjs.com after each release (basically git tags)
+# Source: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#### Description

This adds Github Action to automatically release new git tags into npm registry.

I noticed that the Notion search has been broken for a while from this issue: https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/546

@danni-cool wrote a nice blog post about this problem here: https://danni.cool/fixed-the-broken-search-in-nextjs-notion-starter-kit

If we would automatically deploy the new git tags into npm we wouldn't need to create patches like he is proposing.

Fixes #537.

#### Steps to do before merging ❗ 

- [ ] You should create a access token to NPM following this guide: https://docs.npmjs.com/creating-and-viewing-access-tokens

