### PR TITLE
Table of contents refactor

### DIFF
--- a/packages/notion-utils/src/get-page-table-of-contents.ts
+++ b/packages/notion-utils/src/get-page-table-of-contents.ts
@@ -16,6 +16,50 @@ const indentLevels = {
 }
 
 /**
+ * Recursive function to traverse blocks and build the table of contents.
+ */
+const traverseBlocks = (
+  blockIds: string[],
+  recordMap: types.ExtendedRecordMap,
+  indentLevel: number
+): Array<TableOfContentsEntry> => {
+  const toc: Array<TableOfContentsEntry> = []
+
+  for (const blockId of blockIds) {
+    const block = recordMap.block[blockId]?.value
+
+    if (block) {
+      const { type } = block
+
+      if (
+        type === 'header' ||
+        type === 'sub_header' ||
+        type === 'sub_sub_header'
+      ) {
+        toc.push({
+          id: blockId,
+          type,
+          text: getTextContent(block.properties?.title),
+          indentLevel: indentLevels[type]
+        })
+      }
+
+      // If the block has content, recursively traverse it
+      if (block.content) {
+        const nestedHeaders = traverseBlocks(
+          block.content,
+          recordMap,
+          indentLevel + 1
+        )
+        toc.push(...nestedHeaders)
+      }
+    }
+  }
+
+  return toc
+}
+
+/**
  * Gets the metadata for a table of contents block by parsing the page's
  * H1, H2, and H3 elements.
  */
@@ -23,30 +67,7 @@ export const getPageTableOfContents = (
   page: types.PageBlock,
   recordMap: types.ExtendedRecordMap
 ): Array<TableOfContentsEntry> => {
-  const toc = (page.content ?? [])
-    .map((blockId: string) => {
-      const block = recordMap.block[blockId]?.value
-
-      if (block) {
-        const { type } = block
-
-        if (
-          type === 'header' ||
-          type === 'sub_header' ||
-          type === 'sub_sub_header'
-        ) {
-          return {
-            id: blockId,
-            type,
-            text: getTextContent(block.properties?.title),
-            indentLevel: indentLevels[type]
-          }
-        }
-      }
-
-      return null
-    })
-    .filter(Boolean) as Array<TableOfContentsEntry>
+  const toc = traverseBlocks(page.content ?? [], recordMap, 0)
 
   const indentLevelStack = [
     {

--- a/packages/notion-utils/src/get-page-table-of-contents.ts
+++ b/packages/notion-utils/src/get-page-table-of-contents.ts
@@ -20,8 +20,7 @@ const indentLevels = {
  */
 const traverseBlocks = (
   blockIds: string[],
-  recordMap: types.ExtendedRecordMap,
-  indentLevel: number
+  recordMap: types.ExtendedRecordMap
 ): Array<TableOfContentsEntry> => {
   const toc: Array<TableOfContentsEntry> = []
 
@@ -46,11 +45,7 @@ const traverseBlocks = (
 
       // If the block has content, recursively traverse it
       if (block.content) {
-        const nestedHeaders = traverseBlocks(
-          block.content,
-          recordMap,
-          indentLevel + 1
-        )
+        const nestedHeaders = traverseBlocks(block.content, recordMap)
         toc.push(...nestedHeaders)
       }
     }
@@ -67,7 +62,7 @@ export const getPageTableOfContents = (
   page: types.PageBlock,
   recordMap: types.ExtendedRecordMap
 ): Array<TableOfContentsEntry> => {
-  const toc = traverseBlocks(page.content ?? [], recordMap, 0)
+  const toc = traverseBlocks(page.content ?? [], recordMap)
 
   const indentLevelStack = [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9602,11 +9602,6 @@ normalize-url@^7.0.3:
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-7.0.3.tgz"
   integrity sha512-RiCOdwdPnzvwcBFJE4iI1ss3dMVRIrEzFpn8ftje6iBfzBInqlnRrNhxcLwBEKjPPXQKzm1Ptlxtaiv9wdcj5w==
 
-notion-types@^6.15.6:
-  version "6.15.6"
-  resolved "https://registry.yarnpkg.com/notion-types/-/notion-types-6.15.6.tgz#eabbb28e1c514f421f0ffbf06ecdecd90e8ec8e3"
-  integrity sha512-JgLWDN4oHg/1sNdHDCeKUfdPl1AYsjOTnYkq+Zn7vITPykxbhw7nIxbAJ7owWUTro1cYTPh+GVmdX0mPiZGujg==
-
 npm-bundled@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz"


### PR DESCRIPTION
#### Description
I usually organize my Notion documents into two columns: one for the content itself and another for the table of contents.

To my surprise, the headers from the left column were not appearing in the table of contents:
![Screenshot 2024-02-06 173013](https://github.com/NotionX/react-notion-x/assets/86527054/cc9267b9-e028-4e60-bbf6-dd920f22d440)

Upon inspecting the code, I realized that the `getPageTableOfContents` function only checks for the nearest children blocks of the root page and doesn't inspect sub-blocks for headers.

My changes adds the `traverseBlocks` function to the `get-page-table-of-contents` file, which recursively checks every block for headers:  

![Screenshot 2024-02-06 183837](https://github.com/NotionX/react-notion-x/assets/86527054/238ecc3b-61ee-438c-87f9-ac91a729a8d0)

Following these changes, the table of contents displays all the headers in the same way Notion does when using the two column blocks.

#### Notion Test Page ID
159efb60502b435496e6e37ef8e2ed6f

I'm uncertain of any potential performance impacts by checking every block this way rather than directly filtering the `recordMap`. Any feedback is appreciated! ❤️
