### PR TITLE
Bug: Re-introduce the patch for syntax highlighting issues regarding C++ and F#

### DIFF
--- a/packages/react-notion-x/src/third-party/code.tsx
+++ b/packages/react-notion-x/src/third-party/code.tsx
@@ -28,9 +28,20 @@ export const Code: React.FC<{
   const copyTimeout = React.useRef<number>()
   const { recordMap } = useNotionContext()
   const content = getBlockTitle(block, recordMap)
-  const language = (
-    block.properties?.language?.[0]?.[0] || defaultLanguage
-  ).toLowerCase()
+  const language = (() => {
+    const languageNotion = (
+      block.properties?.language?.[0]?.[0] || defaultLanguage
+    ).toLowerCase()
+
+    switch (languageNotion) {
+      case 'c++':
+        return 'cpp'
+      case 'f#':
+        return 'fsharp'
+      default:
+        return languageNotion
+    }
+  })()
   const caption = block.properties.caption
 
   const codeRef = React.useRef()


### PR DESCRIPTION
> [!TIP]
> Please check out https://github.com/transitive-bullshit/nextjs-notion-starter-kit/pull/605 for a bandaid fix before this PR gets merged.

#### Description

@transitive-bullshit mentioned in #220 that this fix was introduced with the release of v6, but apparently it vanished from `master`, thus the same issue still persists. 

This PR re-introduces the patch to address syntax highlighting issues caused by [Notion](https://developers.notion.com/reference/block#code)-[prism.js](https://prismjs.com/#supported-languages) language identifier mismatch.

Please refer to https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/309 and https://github.com/NotionX/react-notion-x/issues/220 for more context.

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

Before:
![Screenshot 2024-03-19 12 03 32](https://github.com/NotionX/react-notion-x/assets/114868133/9c1ba392-0c02-4032-b424-9b65bc4f2a8e)

After:
![Screenshot 2024-03-19 11 58 14](https://github.com/NotionX/react-notion-x/assets/114868133/4bbe18ba-9a96-4547-b6ef-00e21c45ba0e)

[https://powerium.notion.site/Decoding-Conditionals-A-Dive-into-if-else-switch-case-Lookup-Tables-and-Interfaces-19254846bcb64aac9c340e81518a9dac](https://powerium.notion.site/Decoding-Conditionals-A-Dive-into-if-else-switch-case-Lookup-Tables-and-Interfaces-19254846bcb64aac9c340e81518a9dac)