### PR TITLE
Add missing new attribute 'card_cover_position' to BasePageBlock type

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -153,6 +153,7 @@ export interface BasePageBlock extends BaseBlock {
     page_full_width?: boolean
     page_small_text?: boolean
     page_cover_position?: number
+    card_cover_position?: number
     block_locked?: boolean
     block_locked_by?: string
     page_cover?: string


### PR DESCRIPTION
When the PR #563 was merged the types were not updated and this broke the builds and typing.

After this is added the builds should work again.