### PR TITLE
Fix prettier linting issues from #563

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-card.tsx
+++ b/packages/react-notion-x/src/third-party/collection-card.tsx
@@ -29,7 +29,8 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
   } = ctx
   let coverContent = null
 
-  const { page_cover_position = 0.5, card_cover_position = 0.5 } = block.format || {}
+  const { page_cover_position = 0.5, card_cover_position = 0.5 } =
+    block.format || {}
   const coverPosition = (1 - page_cover_position) * 100
   const cardCoverPosition = (1 - card_cover_position) * 100
 
@@ -59,7 +60,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
             alt={caption || 'notion image'}
             style={{
               objectFit: coverAspect,
-              objectPosition: `center ${cardCoverPosition}%`  
+              objectPosition: `center ${cardCoverPosition}%`
             }}
           />
         )


### PR DESCRIPTION
This is continuation for #567 where I fixed the changed types so that the builds work again after they broke from merging #563.

Before these changes:
```
$ yarn test:prettier
yarn run v1.22.22
$ prettier '**/*.{js,jsx,ts,tsx}' --check
Checking formatting...
[warn] packages/react-notion-x/src/third-party/collection-card.tsx
[warn] Code style issues found in the above file. Forgot to run Prettier?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

So I then ran: `yarn test:prettier --write`

And the result after these changes:
```
$ yarn test:prettier
yarn run v1.22.22
$ prettier '**/*.{js,jsx,ts,tsx}' --check
Checking formatting...
All matched files use Prettier code style!
✨  Done in 2.72s.
```

This should [fix the failing `test:prettier` check](https://github.com/NotionX/react-notion-x/actions/runs/11599836699/job/32298885398).

Sorry that I didn't realize to combine them in the first place 🙇.