### PR TITLE
Fix callout spacing for new callouts (sans icons)

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -838,5 +838,4 @@ export function Block(props: BlockProps) {
 
       return <div />
   }
-
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -592,7 +592,7 @@ export function Block(props: BlockProps) {
               blockId
             )}
           >
-            <PageIcon block={block} />
+            <PageIcon block={block} hideDefaultIcon={true} />
 
             <div className='notion-callout-text'>
               <Text value={block.properties?.title} block={block} />
@@ -839,5 +839,4 @@ export function Block(props: BlockProps) {
       return <div />
   }
 
-  return null
 }

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1199,6 +1199,11 @@ svg.notion-page-icon {
   width: 100%;
 }
 
+.notion-callout-text > *:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
 .notion-toggle {
   width: 100%;
   padding: 3px 2px;


### PR DESCRIPTION
#### Description

See issue https://github.com/NotionX/react-notion-x/issues/565

Notion recently introduced two changes to callouts:
- There is no longer a forced text title and instead we just have block contents, allowing blocks like `<h1>` at the top of a callout.
- You can remove the icon from the callout entirely (this was me 😉).

This led to some minor visual issues with react-notion-x.

In this PR, we: 
- Remove the icon entirely when it is missing 
- Removes the top padding/margins on the callout text's first child.

#### Notion Test Page ID

1425cb08cf2c80efb771e6010d8dac21

**Notion**
![CleanShot 2024-11-18 at 01 07 33@2x](https://github.com/user-attachments/assets/28b28d7e-10cb-4717-913a-7a6982c1f46f)

**Main [before change]**
https://react-notion-x-demo.transitivebullsh.it/1425cb08cf2c80efb771e6010d8dac21

![CleanShot 2024-11-18 at 01 07 19@2x](https://github.com/user-attachments/assets/69097716-5289-43a7-8a4e-76cd22e0cd18)

**After change**
![CleanShot 2024-11-18 at 01 09 22@2x](https://github.com/user-attachments/assets/2d402449-9ee1-4877-b74f-96c32d71b380)

Old callouts are fine too
![CleanShot 2024-11-18 at 01 28 57@2x](https://github.com/user-attachments/assets/20987b87-150d-4746-9167-0629000e1919)

(Note: there seems to be a funny bug with adjacent headings being rendered on the same line 😛. This is not addressed in this PR.)