### PR TITLE
fix: load images by safely add spaceId to searchParams

### DIFF
--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -135,7 +135,9 @@ export function Asset({
   }
 
   if (block.space_id) {
-    source = source.concat('&spaceId=', block.space_id)
+    const url = new URL(source)
+    url.searchParams.set('spaceId', block.space_id)
+    source = url.toString()
   }
 
   let content = null

--- a/packages/react-notion-x/src/components/audio.tsx
+++ b/packages/react-notion-x/src/components/audio.tsx
@@ -16,12 +16,14 @@ export function Audio({
   let source =
     recordMap.signed_urls[block.id] || block.properties?.source?.[0]?.[0]
 
-  if (block.space_id) {
-    source = source?.concat('&spaceId=', block.space_id)
-  }
-
   if (!source) {
     return null
+  }
+
+  if (block.space_id) {
+    const url = new URL(source)
+    url.searchParams.set('spaceId', block.space_id)
+    source = url.toString()
   }
 
   return (

--- a/packages/react-notion-x/src/components/file.tsx
+++ b/packages/react-notion-x/src/components/file.tsx
@@ -23,7 +23,9 @@ export function File({
   }
 
   if (block.space_id) {
-    source = source.concat('&spaceId=', block.space_id)
+    const url = new URL(source)
+    url.searchParams.set('spaceId', block.space_id)
+    source = url.toString()
   }
 
   return (


### PR DESCRIPTION
#### Description

This PR fixes the broken images and files in Notion. 

Before: spaceId was just added with and `&` even if it was the first query params.
Now: spaceId is added safely to the searchParams using URL operations. 

fixes #588 