### PR TITLE
fix: header background color set completely

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -493,6 +493,7 @@
   max-width: 100%;
   white-space: pre-wrap;
   word-break: break-word;
+  width:100%;
 }
 
 .notion-h1 {


### PR DESCRIPTION
#### Description
Background color not filling full width in notion header

added width 100% in notion-h style

### notion
![image](https://github.com/user-attachments/assets/fd1ac5b3-5596-4f09-9489-822dae6d7f5a)

### react-notion-x (before)
![image](https://github.com/user-attachments/assets/74df2364-c5ef-406c-beaf-fb071adbbf36)

### react-notion-x (after)
![image](https://github.com/user-attachments/assets/e002b281-7547-4e41-921b-d27639ed0785)


#### Notion Test Page ID

Notion Page Id : 148e895fae8680ed8002c5966af7771b
