### PR TITLE
feat: add alt text support for images

### DIFF
--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -131,6 +131,7 @@ export interface BaseContentBlock extends BaseBlock {
   properties: {
     source: string[][]
     caption?: Decoration[]
+    alt_text?: Decoration[]
   }
   format?: {
     block_alignment: 'center' | 'left' | 'right'

--- a/packages/react-notion-x/src/components/asset.tsx
+++ b/packages/react-notion-x/src/components/asset.tsx
@@ -280,8 +280,9 @@ export function Asset({
       source = block.properties?.source?.[0]?.[0]
     }
     const src = mapImageUrl(source, block as Block)
+    const altText = getTextContent(block.properties?.alt_text)
     const caption = getTextContent(block.properties?.caption)
-    const alt = caption || 'notion image'
+    const alt = altText || caption || 'notion image'
 
     content = (
       <LazyImage


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

Notion has added ALT text support for images earlier this year (https://x.com/NotionHQ/status/1771216051931361353?lang=en). This PR adds support for specifying alt text on images using this feature.

![image](https://github.com/user-attachments/assets/c11f34fa-68a9-43b7-8098-de3108b08a5a)

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->

- 14d94f8ffdab8022bd2de3eff81d4909
