### PR TITLE
Fix private file signed url generation

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -237,17 +237,17 @@ export class NotionAPI {
         // console.log(block, source)
 
         if (source) {
-          if (!source.includes('secure.notion-static.com')) {
-            return []
+          if (source.includes('secure.notion-static.com') || source.includes('prod-files-secure')) {
+            return {
+              permissionRecord: {
+                table: 'block',
+                id: block.id
+              },
+              url: source
+            };
           }
 
-          return {
-            permissionRecord: {
-              table: 'block',
-              id: block.id
-            },
-            url: source
-          }
+          return []
         }
       }
 

--- a/packages/react-notion-x/src/third-party/pdf.tsx
+++ b/packages/react-notion-x/src/third-party/pdf.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 
 // ensure pdfjs can find its worker script regardless of how react-notion-x is bundled
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`
 
 export function Pdf({ file, ...rest }: { file: string }) {
   const [numPages, setNumPages] = React.useState<number>(0)


### PR DESCRIPTION
#### Description

When trying to display a PDF file, I've figured out that notion is using a new bucket url to serve their files and it impacts how this library handles url signing. 

- Old files start with: `https://s3-us-west-2.amazonaws.com/secure.notion-static.com/...`
- New files start with: `https://prod-files-secure.s3.us-west-2.amazonaws.com/...`

Including `prod-files-secure` prefix when identifying a private url, fixed the issue.

Other than that, the PDF component is using an outdated `pdfjs-dist` cdn url, so i've updated it.


#### Notion Test Page ID

- PDFs not being displayed: `34d650c65da34f888335dbd3ddd141dc`
