### PR TITLE
fix: datebetween formula

### DIFF
--- a/packages/react-notion-x/src/third-party/eval-formula.ts
+++ b/packages/react-notion-x/src/third-party/eval-formula.ts
@@ -375,7 +375,7 @@ function evalFunctionFormula(
             start: date2,
             end: date1
           }) as any
-        )[unit] ?? (0 as number)
+        )[unit] ?? 0
       )
     }
 


### PR DESCRIPTION
#### Description
A few formulas appear to be broken because the wrong argument is being used to determine the `unit`.
Additionally, `intervalToDuration` only returns a property if it has truthy value, despite what the docs indicate. In the case that the `seconds` value is zero, the returned object will not have a `seconds` property defined.

Fixes are:
- Use the correct unit argument
- Default the duration to zero if the result from `intervalToDuration` is undefined.

#### Notion Test Page ID
I have a working formula using `dateBetween` on this page:
https://adaminthehills.notion.site/Hi-I-m-Adam-164d424ea49f80c9b216c4425ca573c8