### PR TITLE
fix: Hydration mismatch on table collection

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-view-table.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-table.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import type * as React from 'react'
 
 import { useNotionContext } from '../context'
 import { type CollectionViewProps } from '../types'
@@ -7,6 +7,7 @@ import { CollectionColumnTitle } from './collection-column-title'
 import { CollectionGroup } from './collection-group'
 import { getCollectionGroups } from './collection-utils'
 import { Property } from './property'
+import { useClientStyle } from './react-use'
 
 const defaultBlockIds: string[] = []
 
@@ -72,21 +73,18 @@ function Table({
 } & Omit<CollectionViewProps, 'collectionData'>) {
   const { recordMap, linkTableTitleProperties } = useNotionContext()
 
-  const tableStyle = React.useMemo(
-    () => ({
+  const tableStyle = useClientStyle(
+    {
       width,
       maxWidth: width
-    }),
-    [width]
+    },
+    { visibility: 'hidden' }
   )
 
-  const tableViewStyle = React.useMemo(
-    () => ({
-      paddingLeft: padding,
-      paddingRight: padding
-    }),
-    [padding]
-  )
+  const tableViewStyle = useClientStyle({
+    paddingLeft: padding,
+    paddingRight: padding
+  })
 
   let properties = []
 

--- a/packages/react-notion-x/src/third-party/react-use.ts
+++ b/packages/react-notion-x/src/third-party/react-use.ts
@@ -211,3 +211,19 @@ export const useLocalStorage = <T>(
 
   return [state, set, remove]
 }
+
+// Style mismatches between server rendering and client hydration can act
+// unpredictably. Style that depends on the client state should use this hook
+// can prevent the unpredictable behavior. More details here:
+// https://github.com/vercel/next.js/issues/17463
+export const useClientStyle = (
+  clientStyle: React.CSSProperties,
+  serverStyle: React.CSSProperties = {}
+) => {
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  return isMounted ? clientStyle : serverStyle
+}


### PR DESCRIPTION
#### Description
Between server rendering and client hydration, there is a mismatch between the styles applied to table collection. This hydration mismatch is because the client depends on the window width, which the server does not have access to.

Hydration mismatches result in [unpredictable behaviour](https://github.com/vercel/next.js/issues/17463). In this case, the server value is being incorrectly preserved. The consequence is that the table renders with the incorrect width, then "jumps" to the correct position when the screen is resized.

The problem:
https://github.com/user-attachments/assets/1b1f9c85-2d3d-4efa-8381-58ddfec5efeb

The proposed fix applies a static style when rendering on the server to prevent the jump, but after mounting, the correct style is then applied. I opted to use `visibility: hidden` for the server state, because otherwise the table immediately performing a transition on page load. It's a brief flash, but less visually impactful than a transition.

After the fix is applied:
https://github.com/user-attachments/assets/459f6e41-ed53-490c-8d05-35617bfa5a3d


#### Notion Test Page ID

https://adaminthehills.notion.site/174d424ea49f805cabc7ec5d4a5a2bfe?v=4a4959c0aa884661a01793045a5d421c&pvs=4
