### PR TITLE
fix(collection): two collection hydration errors

### DIFF
--- a/packages/react-notion-x/src/third-party/collection.tsx
+++ b/packages/react-notion-x/src/third-party/collection.tsx
@@ -115,10 +115,7 @@ function CollectionViewBlock({
     [collectionState, setCollectionState]
   )
 
-  let { width: windowWidth } = useWindowSize()
-  if (isServer) {
-    windowWidth = 1024
-  }
+  const { width: windowWidth } = useWindowSize()
 
   const collection = recordMap.collection[collectionId]?.value
   const collectionView = recordMap.collection_view[collectionViewId]?.value
@@ -152,7 +149,7 @@ function CollectionViewBlock({
     }
 
     const padding =
-      isServer && !isMounted ? 96 : Math.trunc((width - notionBodyWidth) / 2)
+      isServer || !isMounted ? 96 : Math.trunc((width - notionBodyWidth) / 2)
     style.paddingLeft = padding
     style.paddingRight = padding
 
@@ -161,7 +158,12 @@ function CollectionViewBlock({
       width,
       padding
     }
-  }, [windowWidth, parentPage, collectionView?.type, isMounted])
+  }, [
+    collectionView?.type,
+    windowWidth,
+    parentPage?.format?.page_full_width,
+    isMounted
+  ])
 
   // console.log({
   //   width,

--- a/packages/react-notion-x/src/third-party/react-use.ts
+++ b/packages/react-notion-x/src/third-party/react-use.ts
@@ -40,34 +40,32 @@ function off<T extends Window | Document | HTMLElement | EventTarget>(
 
 const isBrowser = typeof window !== 'undefined'
 
-export const useWindowSize = (
-  initialWidth = Infinity,
-  initialHeight = Infinity
-) => {
-  const [state, setState] = useRafState<{ width: number; height: number }>({
-    width: isBrowser ? window.innerWidth : initialWidth,
-    height: isBrowser ? window.innerHeight : initialHeight
+export const useWindowSize = (initialWidth = 1024, initialHeight = 768) => {
+  const [dimensions, setDimensions] = useRafState<{
+    width: number
+    height: number
+  }>({
+    width: initialWidth,
+    height: initialHeight
   })
 
   useEffect((): (() => void) | void => {
     if (isBrowser) {
       const handler = () => {
-        setState({
+        setDimensions({
           width: window.innerWidth,
           height: window.innerHeight
         })
       }
 
       on(window, 'resize', handler)
-
-      return () => {
-        off(window, 'resize', handler)
-      }
+      handler()
+      return () => off(window, 'resize', handler)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return state
+  return dimensions
 }
 
 export const useEffectOnce = (effect: EffectCallback) => {


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

- change `useWindowSize` hook to ensure for ssr result to match when hydration.
- fixed two hydration errors caused by `windowWidth` and `padding`

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/ae54bdc2-321b-4ae2-a59e-5c9081482559" />


#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
