### PR TITLE
Fix: title key can't exist inside title, rich_text should be the key

### DIFF
--- a/packages/notion-compat/src/convert-block.ts
+++ b/packages/notion-compat/src/convert-block.ts
@@ -227,7 +227,7 @@ export function convertBlock({
         if (page) {
           if (page.properties.title) {
             compatBlock.properties.title = convertRichText(
-              (page.properties.title as any).title
+              (page.properties.title as any).rich_text
             )
           }
 


### PR DESCRIPTION
#### Description

For notion-compat,

while converting blocks, the child_page typed block have title, to convert that we need to access rich text of that title, byt we are trying to access title.title, so it's undefined and throwing error.

