### PR TITLE
feat: add mention link support

### DIFF
--- a/packages/notion-types/src/core.ts
+++ b/packages/notion-types/src/core.ts
@@ -119,6 +119,13 @@ export type InlineEquationFormat = ['e', string]
 export type DiscussionFormat = ['m', string]
 export type ExternalLinkFormat = ['‣', [string, string]]
 export type DateFormat = ['d', FormattedDate]
+export type MotionLinkFormat = ['lm', Record<MotionLinkContentKeys, string>]
+
+export type MotionLinkContentKeys =
+  | 'href'
+  | 'title'
+  | 'icon_url'
+  | 'description'
 
 export interface FormattedDate {
   type: 'date' | 'daterange' | 'datetime' | 'datetimerange'
@@ -145,6 +152,7 @@ export type SubDecoration =
   | ExternalLinkFormat
   | DiscussionFormat
   | ExternalObjectInstanceFormat
+  | MotionLinkFormat
 
 export type BaseDecoration = [string]
 export type AdditionalDecoration = [string, SubDecoration[]]

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -11,6 +11,7 @@ import { formatDate, getHashFragmentValue } from '../utils'
 import { EOI } from './eoi'
 import { GracefulImage } from './graceful-image'
 import { PageTitle } from './page-title'
+import { LazyImage } from './lazy-image'
 
 /**
  * Renders a single piece of Notion text, including basic rich text formatting.
@@ -126,6 +127,32 @@ export function Text({
                     )
                   }
                 }
+              }
+
+              case 'lm': {
+                const linkContent = decorator[1]
+                return (
+                  <components.Link
+                    className='notion-link'
+                    href={linkContent.href}
+                    {...linkProps}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    <span className='notion-page-title notion-mention-title'>
+                      <div className='notion-page-icon-inline notion-page-icon-image'>
+                        <LazyImage
+                          src={linkContent.icon_url}
+                          alt={linkContent.title}
+                          className='notion-page-title-icon notion-page-icon'
+                        />
+                      </div>
+                      <span className='notion-page-title-text notion-mention-title-text'>
+                        {linkContent.title}
+                      </span>
+                    </span>
+                  </components.Link>
+                )
               }
 
               case 'h':


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

Fixed an issue where the newly introduced "Link Mention" feature in Notion was unsupported, causing an "unsupported text format" error.
![Clip_20250306_005559](https://github.com/user-attachments/assets/c93d7a75-fc23-4e22-b69c-1f6ffc8b0de0)

It can now be displayed in a manner similar to page link

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
