### PR TITLE
fix: look for `attachment:` in file upload source

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -239,7 +239,8 @@ export class NotionAPI {
         if (source) {
           if (
             source.includes('secure.notion-static.com') ||
-            source.includes('prod-files-secure')
+            source.includes('prod-files-secure') ||
+            source.includes('attachment:')
           ) {
             return {
               permissionRecord: {


### PR DESCRIPTION
#### Description

Notion file uploads now append `attachment:` to the file identifier instead of the s3 url.

Therefore the source is also a valid source if it includes `attachment:` in the source text.


#### Notion Test Page ID

Here's an example of a Notion page

1b2d3f870f0080caae0bc0b2766cf31f