### PR TITLE
Add Contribution Guide for PR Process and Lint Test in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --strict-peer-dependencies
 
+      - name: Run lint
+        run: pnpm run test:lint
+
       - name: Run test
         run: pnpm test
 

--- a/contributing.md
+++ b/contributing.md
@@ -40,3 +40,33 @@ Whenever you make a change to one of the packages, the `pnpm dev` from the proje
 Sometimes, this process gets a little out of whack, and if you're not sure what's going on, I usually just quit one or both of the `pnpm dev` commands and restart them.
 
 If you're seeing something unexpected while debugging one of the Next.js demos, try running `rm -rf .next` to refresh the Next.js cache before running `pnpm dev` again.
+
+## Before Pull Request
+
+Before submitting your pull request, please check the following:
+
+1. Run linting:
+
+```bash
+pnpm run test:lint
+```
+
+If there are any linting errors, please fix them before proceeding with the PR. This helps maintain consistent code quality across the project.
+
+2. Run tests:
+
+```bash
+pnpm test
+```
+
+Ensure that all the tests pass before submitting your PR. This verifies that your changes don't break existing functionality.
+
+3. Build the project:
+
+```bash
+pnpm build
+```
+
+Ensure that the project can be built successfully. This confirms that your changes are compatible with the build process.
+
+If all these steps pass, your code is ready for the pull request.


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

We’ve merged the #604 feature into the master branch, but unfortunately, an ESLint error was overlooked during the review process. The issue was addressed and fixed in PR #614.

To prevent similar situations in the future, I would like to suggest updating the contribution guide and GitHub Actions for PRs to include an automated lint check.

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
