### PR TITLE
feat: add page icon align option

### DIFF
--- a/packages/react-notion-x/src/components/page-icon.tsx
+++ b/packages/react-notion-x/src/components/page-icon.tsx
@@ -21,13 +21,15 @@ export function PageIconImpl({
   className,
   inline = true,
   hideDefaultIcon = false,
-  defaultIcon
+  defaultIcon,
+  alignCenter = false
 }: {
   block: Block
   className?: string
   inline?: boolean
   hideDefaultIcon?: boolean
   defaultIcon?: string | null
+  alignCenter?: boolean
 }) {
   const { mapImageUrl, recordMap, darkMode } = useNotionContext()
   let isImage = false
@@ -94,7 +96,8 @@ export function PageIconImpl({
     <div
       className={cs(
         inline ? 'notion-page-icon-inline' : 'notion-page-icon-hero',
-        isImage ? 'notion-page-icon-image' : 'notion-page-icon-span'
+        isImage ? 'notion-page-icon-image' : 'notion-page-icon-span',
+        alignCenter ? 'align-center' : 'align-left'
       )}
     >
       {content}

--- a/packages/react-notion-x/src/components/page-icon.tsx
+++ b/packages/react-notion-x/src/components/page-icon.tsx
@@ -21,17 +21,15 @@ export function PageIconImpl({
   className,
   inline = true,
   hideDefaultIcon = false,
-  defaultIcon,
-  alignCenter = false
+  defaultIcon
 }: {
   block: Block
   className?: string
   inline?: boolean
   hideDefaultIcon?: boolean
   defaultIcon?: string | null
-  alignCenter?: boolean
 }) {
-  const { mapImageUrl, recordMap, darkMode } = useNotionContext()
+  const { alignCenter, mapImageUrl, recordMap, darkMode } = useNotionContext()
   let isImage = false
   let content: any = null
 

--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -35,6 +35,7 @@ export interface NotionContext {
   minTableOfContentsItems: number
   linkTableTitleProperties: boolean
   isLinkCollectionToUrlProperty: boolean
+  alignCenter: boolean
 
   defaultPageIcon?: string | null
   defaultPageCover?: string | null
@@ -63,6 +64,7 @@ export interface PartialNotionContext {
   showCollectionViewDropdown?: boolean
   linkTableTitleProperties?: boolean
   isLinkCollectionToUrlProperty?: boolean
+  alignCenter?: boolean
 
   showTableOfContents?: boolean
   minTableOfContentsItems?: number
@@ -169,6 +171,7 @@ const defaultNotionContext: NotionContext = {
   showCollectionViewDropdown: true,
   linkTableTitleProperties: true,
   isLinkCollectionToUrlProperty: false,
+  alignCenter: true,
 
   showTableOfContents: false,
   minTableOfContentsItems: 3,

--- a/packages/react-notion-x/src/renderer.tsx
+++ b/packages/react-notion-x/src/renderer.tsx
@@ -34,6 +34,7 @@ export function NotionRenderer({
   defaultPageIcon,
   defaultPageCover,
   defaultPageCoverPosition,
+  alignCenter,
   ...rest
 }: {
   recordMap: ExtendedRecordMap
@@ -59,6 +60,7 @@ export function NotionRenderer({
   linkTableTitleProperties?: boolean
   isLinkCollectionToUrlProperty?: boolean
   isImageZoomable?: boolean
+  alignCenter?: boolean
 
   showTableOfContents?: boolean
   minTableOfContentsItems?: number
@@ -117,6 +119,7 @@ export function NotionRenderer({
       defaultPageCover={defaultPageCover}
       defaultPageCoverPosition={defaultPageCoverPosition}
       zoom={isImageZoomable ? zoom : null}
+      alignCenter={alignCenter}
     >
       <NotionBlockRenderer {...rest} />
     </NotionContextProvider>

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -631,12 +631,31 @@
 .notion-page-icon-hero.notion-page-icon-image {
   width: 124px;
   height: 124px;
-  margin-left: 11px;
+}
+
+.notion-page-icon-hero.notion-page-icon-image.align-left {
+  left: 0%;
+  margin-left: 26px;
+}
+
+.notion-page-icon-hero.notion-page-icon-image.align-center {
+  left: 50%;
+  margin-left: -62px;
 }
 
 .notion-page-icon-hero.notion-page-icon-span {
   height: 78px;
   width: 78px;
+  margin-left: -39px;
+}
+
+.notion-page-icon-hero.notion-page-icon-span.align-left {
+  left: 0%;
+  margin-left: 16px;
+}
+
+.notion-page-icon-hero.notion-page-icon-span.align-center {
+  left: 50%;
   margin-left: -39px;
 }
 

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -623,7 +623,6 @@
 .notion-page-icon-hero {
   position: absolute;
   top: 0;
-  left: 50%;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -632,7 +631,7 @@
 .notion-page-icon-hero.notion-page-icon-image {
   width: 124px;
   height: 124px;
-  margin-left: -62px;
+  margin-left: 11px;
 }
 
 .notion-page-icon-hero.notion-page-icon-span {


### PR DESCRIPTION
#### Description

Some users prefer the default Notion page icon alignment style. To accommodate this preference, this PR introduces the `alignCenter` option in `NotionRenderer`.

- Added `alignCenter` prop to `NotionRenderer` to allow customizable page icon alignment.
- Adjusted related CSS styles to ensure proper icon positioning.

