### PR TITLE
Fix/suggested edits markup appears in rendered text

### DIFF
--- a/packages/notion-types/src/core.ts
+++ b/packages/notion-types/src/core.ts
@@ -120,6 +120,7 @@ export type DiscussionFormat = ['m', string]
 export type ExternalLinkFormat = ['‣', [string, string]]
 export type DateFormat = ['d', FormattedDate]
 export type LinkMentionFormat = ['lm', string]
+export type SuggestionEditFormat = ['si', string]
 
 export interface FormattedDate {
   type: 'date' | 'daterange' | 'datetime' | 'datetimerange'
@@ -147,6 +148,7 @@ export type SubDecoration =
   | DiscussionFormat
   | ExternalObjectInstanceFormat
   | LinkMentionFormat
+  | SuggestionEditFormat
 
 export type BaseDecoration = [string]
 export type AdditionalDecoration = [string, SubDecoration[]]

--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -259,6 +259,9 @@ export function Text({
                 return <EOI block={externalObjectInstance} inline={true} />
               }
 
+              case 'si':
+                return null
+
               default:
                 if (process.env.NODE_ENV !== 'production') {
                   console.log('unsupported text format', decorator)


### PR DESCRIPTION
#### Description

Description
Notion’s new "Suggest Edits" feature now causes suggestion markup to appear in the rendered text by react-notion-x, which affects readability. The markup should be hidden or filtered out.

<img width="812" alt="Screenshot 2025-03-25 at 11 48 16" src="https://github.com/user-attachments/assets/dd58a167-0857-42f9-b1c9-e32e89c68fec" />

**Before the fix:**

<img width="960" alt="Screenshot 2025-03-25 at 11 49 38" src="https://github.com/user-attachments/assets/2f4c4be0-a6a8-4f0b-92de-b4eab5be256f" />

**After the fix**

<img width="768" alt="Screenshot 2025-03-25 at 11 56 36" src="https://github.com/user-attachments/assets/f63835ed-baa6-496a-ac20-d1de0523306b" />




#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
