### PR TITLE
fix(link-mention): add `referrerPolicy="same-origin"` to image tags to prevent preview issues

### DIFF
--- a/packages/react-notion-x/src/components/link-mention.tsx
+++ b/packages/react-notion-x/src/components/link-mention.tsx
@@ -49,6 +49,7 @@ function LinkMentionPreview({ metadata }: { metadata: LinkMentionData }) {
           className='notion-link-mention-preview-thumbnail'
           src={metadata.thumbnail_url}
           alt={metadata.title}
+          referrerPolicy='same-origin'
         />
         <div className='notion-link-mention-preview-content'>
           <p className='notion-link-mention-preview-title'>{metadata.title}</p>
@@ -60,6 +61,7 @@ function LinkMentionPreview({ metadata }: { metadata: LinkMentionData }) {
               className='notion-link-mention-preview-icon'
               src={metadata.icon_url}
               alt={metadata.link_provider}
+              referrerPolicy='same-origin'
             />
             <span className='notion-link-mention-preview-provider'>
               {metadata.link_provider}


### PR DESCRIPTION
#### Description

This PR adds `referrerPolicy="same-origin"` to `<img>` elements inside the `LinkMentionPreview` component.

Some external preview thumbnails (such as images hosted on Naver Blog) were not being displayed due to cross-origin Referrer-based access restrictions. These servers often block image requests with foreign Referer headers to prevent hotlinking.

By explicitly setting `referrerPolicy="same-origin"`, we suppress the `Referer` header on cross-origin image requests, improving compatibility with such services and preventing image preview failures.

This fix should help resolve thumbnail breakage for many Notion links that point to external content providers with strict CORS or Referer policies.

#### Notion Test Page ID

`aa408b24c0e74b61b0165cf937975663`

<!-- This page includes a LinkMention referencing a Naver Blog thumbnail image that previously failed to load -->

#### results

<table>
  <tr>
    <td align="center"><strong>before</strong></td>
    <td align="center"><strong>after</strong></td>
  </tr>
  <tr>
    <td><img width="400" alt="스크린샷 2025-04-09 오후 11 48 12" src="https://github.com/user-attachments/assets/fb0cf44e-7203-401b-982b-23c3f68154ba" /></td>
    <td><img width="400" alt="Image" src="https://github.com/user-attachments/assets/44f5e603-87ee-4c8b-bd0e-b8d6392b55b1" /></td>
  </tr>
</table>
