### PR TITLE
fix: Divider Line not rendering on pages

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2980,7 +2980,7 @@ svg.notion-page-icon {
 .notion-link-mention {
   position: relative;
   display: inline-flex;
-  align-items: center;
+  align-items: center; 
   vertical-align: middle;
 }
 
@@ -3022,8 +3022,8 @@ svg.notion-page-icon {
 }
 
 .notion-link-mention-card {
-  width: 18rem;
-  height: 15rem;
+  width: 18rem; 
+  height: 15rem; 
   background: var(--bg-color);
   border-radius: 0.75rem;
   border: 1px solid rgba(27, 31, 36, 0.15);


### PR DESCRIPTION
#### Description

Fixes [issue #624](https://github.com/NotionX/react-notion-x/issues/624) where the divider line renders in the test repo but not when used as an imported library. This styling change ensures consistent rendering in both cases. 

Also updated the color to var(--bg-color-0) instead of var(--fg-color-0) for better alignment with Notion’s divider in dark mode. Open to suggestions.

Before:
<img width="726" alt="Screenshot 2025-04-21 at 3 25 32 PM" src="https://github.com/user-attachments/assets/746b34d5-dcd1-4c6e-a29b-bb4fd91fecee" />


After:
<img width="849" alt="Screenshot 2025-04-21 at 3 24 49 PM" src="https://github.com/user-attachments/assets/a85cf01b-c59c-48fc-a179-050b173fa698" />




#### Using `var(--bg-color-0)` instead of `var(--fg-color-0)` in dark mode:
before:
<img width="928" alt="Screenshot 2025-04-21 at 3 19 59 PM" src="https://github.com/user-attachments/assets/31fb7990-328b-490e-8597-7231c47eae6e" />

after:
<img width="959" alt="Screenshot 2025-04-21 at 3 20 14 PM" src="https://github.com/user-attachments/assets/76b335dc-a52a-42f0-87f9-24c69d99dae2" />


#### Notion Test Page ID
`Divider-Line-Test-Page-1dc0afa84937808fa9bbc109b4f337f6`

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
