### PR TITLE
Add multi-level numbered list styles with proper nesting

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -23,7 +23,13 @@ import { SyncPointerBlock } from './components/sync-pointer-block'
 import { Text } from './components/text'
 import { useNotionContext } from './context'
 import { LinkIcon } from './icons/link-icon'
-import { cs, getListNumber, isUrl } from './utils'
+import {
+  cs,
+  getListNestingLevel,
+  getListNumber,
+  getListStyle,
+  isUrl
+} from './utils'
 
 interface BlockProps {
   block: types.Block
@@ -433,6 +439,15 @@ export function Block(props: BlockProps) {
           <ol
             start={start}
             className={cs('notion-list', 'notion-list-numbered', blockId)}
+            style={
+              block.type === 'numbered_list'
+                ? {
+                    listStyleType: getListStyle(
+                      getListNestingLevel(block.id, recordMap.block)
+                    )
+                  }
+                : undefined
+            }
           >
             {content}
           </ol>

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -454,18 +454,42 @@ export function Block(props: BlockProps) {
         )
 
       let output: React.ReactNode | null = null
+      const isTopLevel =
+        block.type !== recordMap.block[block.parent_id]?.value?.type
+      const start = getListNumber(block.id, recordMap.block)
 
       if (block.content) {
-        output = (
-          <>
-            {block.properties && (
-              <li>
-                <Text value={block.properties.title} block={block} />
-              </li>
-            )}
-            {wrapList(children)}
-          </>
-        )
+        const listItem = block.properties ? (
+          <li>
+            <Text value={block.properties.title} block={block} />
+          </li>
+        ) : null
+
+        if (block.type === 'bulleted_list') {
+          output = (
+            <>
+              {listItem}
+              <ul className={cs('notion-list', 'notion-list-disc', blockId)}>
+                {children}
+              </ul>
+            </>
+          )
+        } else {
+          const nestingLevel = getListNestingLevel(block.id, recordMap.block)
+          output = (
+            <>
+              {listItem}
+              <ol
+                className={cs('notion-list', 'notion-list-numbered', blockId)}
+                style={{
+                  listStyleType: getListStyle(nestingLevel + 1)
+                }}
+              >
+                {children}
+              </ol>
+            </>
+          )
+        }
       } else {
         output = block.properties ? (
           <li>
@@ -473,10 +497,6 @@ export function Block(props: BlockProps) {
           </li>
         ) : null
       }
-
-      const isTopLevel =
-        block.type !== recordMap.block[block.parent_id]?.value?.type
-      const start = getListNumber(block.id, recordMap.block)
 
       return isTopLevel ? wrapList(output, start) : output
     }

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -852,6 +852,18 @@ svg.notion-page-icon {
   margin-bottom: 0;
 }
 
+.notion-list-numbered ol {
+  list-style-type: lower-alpha;
+}
+
+.notion-list-numbered ol ol {
+  list-style-type: lower-roman;
+}
+
+.notion-list-numbered ol ol ol {
+  list-style-type: decimal;
+}
+
 .notion-list-disc li {
   padding-left: 0.1em;
 }

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -852,18 +852,6 @@ svg.notion-page-icon {
   margin-bottom: 0;
 }
 
-.notion-list-numbered ol {
-  list-style-type: lower-alpha;
-}
-
-.notion-list-numbered ol ol {
-  list-style-type: lower-roman;
-}
-
-.notion-list-numbered ol ol ol {
-  list-style-type: decimal;
-}
-
 .notion-list-disc li {
   padding-left: 0.1em;
 }

--- a/packages/react-notion-x/src/utils.ts
+++ b/packages/react-notion-x/src/utils.ts
@@ -48,6 +48,38 @@ export const getListNumber = (blockId: string, blockMap: BlockMap) => {
   return group.indexOf(blockId) + 1
 }
 
+export const getListNestingLevel = (
+  blockId: string,
+  blockMap: BlockMap
+): number => {
+  let level = 0
+  let currentBlockId = blockId
+
+  while (true) {
+    const parentId = blockMap[currentBlockId]?.value?.parent_id
+
+    if (!parentId) break
+
+    const parentBlock = blockMap[parentId]?.value
+    if (!parentBlock) break
+
+    if (parentBlock.type === 'numbered_list') {
+      level++
+      currentBlockId = parentId
+    } else {
+      break
+    }
+  }
+
+  return level
+}
+
+export const getListStyle = (level: number): string => {
+  const styles: string[] = ['decimal', 'lower-alpha', 'lower-roman']
+  const index = ((level % styles.length) + styles.length) % styles.length
+  return styles[index] as string
+}
+
 export const getHashFragmentValue = (url: string) => {
   return url.includes('#') ? url.replace(/^.+(#.+)$/, '$1') : ''
 }


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

Fixes #548 

In the current implementation, all levels of nested numbered lists use the same decimal numbering style (1, 2, 3...), regardless of nesting depth. This makes it difficult to distinguish between different levels of nested lists and doesn't follow standard document formatting conventions.

This PR introduces proper styling for nested numbered lists by:

1. Adding a new getListNestingLevel function to determine the nesting level of a list item
2. Adding a new getListStyle function to cycle through appropriate list styles based on nesting level
3. Modifying the list rendering logic to apply the correct style to each level of nested lists

**Before**
<img width="1408" alt="image" src="https://github.com/user-attachments/assets/0df0338f-d104-44d7-affc-a3c628fec424" />


**After**
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/bb6ee58d-fcd5-4e7f-a7d5-057e67466a58" />


#### Notion Test Page ID

1e31578febe580e5847ac4314e304b02

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
