### PR TITLE
fix: notion-compat page title missing richtext causes convert failure

### DIFF
--- a/packages/notion-compat/src/convert-block.ts
+++ b/packages/notion-compat/src/convert-block.ts
@@ -225,7 +225,7 @@ export function convertBlock({
       if (pageMap) {
         const page = pageMap[block.id] as types.Page
         if (page) {
-          if (page.properties.title) {
+          if (page.properties.title?.rich_text) {
             compatBlock.properties.title = convertRichText(
               (page.properties.title as any).rich_text
             )


### PR DESCRIPTION
#### Description

Since I upgraded from v6 to the latest v7, I found an unexpected issue with `notion-compat` API client.

(I'm not an expert on Notion API, so sorry for the possibly incorrect description) My Notion page has for some reason title as `plaintext`, not `rich_text` and then `convertRichText()` fails due undefined parameter: `Cannot read properties of undefined (reading 'map')`.

I added this basic check, which fixed the case on my project.

#### Notion Test Page ID

Notion page ID: `1e4b49ae084b809597f6c5bd5167d82c`