### PR TITLE
feat: table header rendering optimization

### DIFF
--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -789,6 +789,10 @@ export function Block(props: BlockProps) {
       const formatMap = tableBlock.format?.table_block_column_format
       const backgroundColor = block.format?.block_color
 
+      const hasRowHeader = tableBlock.format?.table_block_column_header === true
+
+      const isHeaderRow = hasRowHeader && tableBlock.content?.[0] === block.id
+
       if (!tableBlock || !order) {
         return null
       }
@@ -798,6 +802,7 @@ export function Block(props: BlockProps) {
           className={cs(
             'notion-simple-table-row',
             backgroundColor && `notion-${backgroundColor}`,
+            isHeaderRow && 'notion-simple-table-header-row',
             blockId
           )}
         >

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -790,6 +790,7 @@ export function Block(props: BlockProps) {
       const backgroundColor = block.format?.block_color
 
       const hasRowHeader = tableBlock.format?.table_block_column_header === true
+      const hasColumnHeader = tableBlock.format?.table_block_row_header === true
 
       const isHeaderRow = hasRowHeader && tableBlock.content?.[0] === block.id
 
@@ -806,13 +807,18 @@ export function Block(props: BlockProps) {
             blockId
           )}
         >
-          {order.map((column) => {
+          {order.map((column, columnIndex) => {
             const color = formatMap?.[column]?.color
+
+            const isHeaderColumn = hasColumnHeader && columnIndex === 0
 
             return (
               <td
                 key={column}
-                className={color ? `notion-${color}` : ''}
+                className={cs(
+                  color ? `notion-${color}` : '',
+                  isHeaderColumn && 'notion-simple-table-header-cell'
+                )}
                 style={{
                   width: formatMap?.[column]?.width || 120
                 }}

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2672,7 +2672,7 @@ svg.notion-page-icon {
   font-size: 14px;
 }
 
-.notion-simple-table tr:first-child td {
+.notion-simple-table-header-row td {
   background: var(--bg-color-0);
 }
 

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -2672,7 +2672,14 @@ svg.notion-page-icon {
   font-size: 14px;
 }
 
+/* simple table header */
+/* row header */
 .notion-simple-table-header-row td {
+  background: var(--bg-color-0);
+}
+
+/* column header */
+.notion-simple-table-header-cell {
   background: var(--bg-color-0);
 }
 


### PR DESCRIPTION
#### Description

Fixes #628 

Simple tables always show the first row with header styling (background color), regardless of whether header settings are enabled. This is inconsistent with Notion's native behavior.

This PR fixes table header rendering to only apply styling when explicitly enabled:

- Row headers (first row): Only styled when `table_block_column_header` is true
- Column headers (first column): Only styled when `table_block_row_header` is true

Note: There's an interesting naming confusion in Notion's API - table_block_column_header actually controls row headers, while table_block_row_header controls column headers. This PR maintains the original field names for API compatibility but implements the correct behavior.

**After**
<img width="762" alt="image" src="https://github.com/user-attachments/assets/a1b92917-2aaa-4141-8735-eed22d23d4c9" />



<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

1eb1578febe58070a07edf70bd34025d

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
