### PR TITLE
fix: display page icons in collection list view

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1657,6 +1657,8 @@ svg.notion-page-icon {
 }
 
 .notion-list-item-title {
+  display: flex;
+  align-items: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/react-notion-x/src/third-party/collection-view-list.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-list.tsx
@@ -2,6 +2,7 @@ import type * as types from 'notion-types'
 import type * as React from 'react'
 import { type PageBlock } from 'notion-types'
 
+import { PageIcon } from '../components/page-icon'
 import { useNotionContext } from '../context'
 import { type CollectionViewProps } from '../types'
 import { CollectionGroup } from './collection-group'
@@ -72,6 +73,11 @@ function List({
                 key={blockId}
               >
                 <div className='notion-list-item-title'>
+                  <PageIcon
+                    block={block}
+                    className='notion-page-title-icon'
+                    hideDefaultIcon
+                  />
                   <Property
                     schema={titleSchema}
                     data={titleData}


### PR DESCRIPTION
#### Description

In Notion, when using a collection_view of type list, the list items only display the page title without showing the corresponding page icon.

#### Solution
1. Import the PageIcon component in the `collection-view-list.tsx` file
2. Add the PageIcon component to the title rendering section of list items
3. Modify the CSS styles to ensure the icon and title are displayed horizontally in the same line

Before
<img width="721" alt="image" src="https://github.com/user-attachments/assets/3b88641f-c71e-46ad-91d0-b1a79ca50e8b" />


After
<img width="734" alt="image" src="https://github.com/user-attachments/assets/e6b19ac7-d0ff-4f5d-96cb-65b04531401f" />


<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID
1ec1578febe580ad8dc5fca79f736e30

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
