### PR TITLE
Fix/support multi relation property

### DIFF
--- a/examples/full/lib/notion.ts
+++ b/examples/full/lib/notion.ts
@@ -21,7 +21,7 @@ if (useOfficialNotionAPI) {
 }
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  const recordMap = await notion.getPage(pageId)
+  const recordMap = await notion.getPage(pageId, { fetchRelationPages: true })
 
   if (previewImagesEnabled) {
     const previewImageMap = await getPreviewImageMap(recordMap)

--- a/examples/minimal/pages/[pageId].tsx
+++ b/examples/minimal/pages/[pageId].tsx
@@ -6,7 +6,7 @@ import notion from '../lib/notion'
 
 export const getStaticProps = async (context: any) => {
   const pageId = (context.params.pageId as string) || rootNotionPageId
-  const recordMap = await notion.getPage(pageId, { fetchRelationPages: true })
+  const recordMap = await notion.getPage(pageId)
 
   return {
     props: {

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -53,7 +53,7 @@ export class NotionAPI {
       chunkNumber = 0,
       throwOnCollectionErrors = false,
       collectionReducerLimit = 999,
-      fetchRelationPages = true, // New option
+      fetchRelationPages = false,
       kyOptions
     }: {
       concurrency?: number
@@ -64,7 +64,7 @@ export class NotionAPI {
       chunkNumber?: number
       throwOnCollectionErrors?: boolean
       collectionReducerLimit?: number
-      fetchRelationPages?: boolean // New option
+      fetchRelationPages?: boolean
       kyOptions?: KyOptions
     } = {}
   ): Promise<notion.ExtendedRecordMap> {


### PR DESCRIPTION
#### Description

A database with sub-items enabled 
Add multiple sub-items to a single "parent" page
Open parent page:
Previously: It showed only the first child/sub-item as the returned recordMap only included the full information of the first, and only the Ids of the others
Now: It attempts to fetch all children/sub-items blocks and shows them as expected
