### PR TITLE
fix: display headings in sync blocks as block elements

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -531,6 +531,16 @@
   opacity: 1;
 }
 
+/* Add specific styles for headings in sync blocks */
+.notion-sync-block .notion-h {
+  display: block;
+}
+
+/* Preserve original styles for toggle headings */
+details.notion-toggle .notion-h {
+  display: inline;
+}
+
 .notion-hash-link {
   opacity: 0;
   text-decoration: none;


### PR DESCRIPTION
#### Description

when creating multiple headings (h1, h2, h3) inside a synced block in Notion, they are displayed inline on the same line instead of as separate block elements.

#### Solution

add specific CSS rules to make headings within synced blocks display as block elements, while preserving the inline display for toggle headings to maintain their functionality

**Before**
<img width="803" alt="image" src="https://github.com/user-attachments/assets/ab459505-edf9-42f3-81d0-fa13b0151f5f" />

**After**
<img width="883" alt="image" src="https://github.com/user-attachments/assets/696c8312-ebd7-4e3a-935d-441db6446f34" />

#### Notion Test Page ID

2021578febe5800ba68dd389f3213db6

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
