### PR TITLE
Fix/notion form rendering

### DIFF
--- a/examples/full/lib/notion.ts
+++ b/examples/full/lib/notion.ts
@@ -23,7 +23,7 @@ if (useOfficialNotionAPI) {
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
   const recordMap = await notion.getPage(pageId, {
     fetchRelationPages: true,
-    embeddedFormBaseUrl: 'https://tekunda.notion.site'
+    embeddedFormsBaseUrl: 'https://tekunda.notion.site'
   })
 
   if (previewImagesEnabled) {

--- a/examples/full/lib/notion.ts
+++ b/examples/full/lib/notion.ts
@@ -21,7 +21,10 @@ if (useOfficialNotionAPI) {
 }
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  const recordMap = await notion.getPage(pageId, { fetchRelationPages: true })
+  const recordMap = await notion.getPage(pageId, {
+    fetchRelationPages: true,
+    embeddedFormBaseUrl: 'https://tekunda.notion.site'
+  })
 
   if (previewImagesEnabled) {
     const previewImageMap = await getPreviewImageMap(recordMap)

--- a/examples/full/lib/notion.ts
+++ b/examples/full/lib/notion.ts
@@ -21,7 +21,7 @@ if (useOfficialNotionAPI) {
 }
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  const recordMap = await notion.getPage(pageId)
+  const recordMap = await notion.getPage(pageId, { fetchRelationPages: true })
 
   if (previewImagesEnabled) {
     const previewImageMap = await getPreviewImageMap(recordMap)

--- a/examples/full/next-env.d.ts
+++ b/examples/full/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/full/styles/globals.css
+++ b/examples/full/styles/globals.css
@@ -6,3 +6,7 @@ body {
   padding: 0;
   margin: 0;
 }
+
+.notion-form-iframe {
+  height: 3500px;
+}

--- a/examples/minimal/next-env.d.ts
+++ b/examples/minimal/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/minimal/pages/[pageId].tsx
+++ b/examples/minimal/pages/[pageId].tsx
@@ -6,7 +6,7 @@ import notion from '../lib/notion'
 
 export const getStaticProps = async (context) => {
   const pageId = (context.params.pageId as string) || rootNotionPageId
-  const recordMap = await notion.getPage(pageId)
+  const recordMap = await notion.getPage(pageId, { fetchRelationPages: true })
 
   return {
     props: {

--- a/examples/minimal/pages/[pageId].tsx
+++ b/examples/minimal/pages/[pageId].tsx
@@ -6,7 +6,7 @@ import notion from '../lib/notion'
 
 export const getStaticProps = async (context) => {
   const pageId = (context.params.pageId as string) || rootNotionPageId
-  const recordMap = await notion.getPage(pageId, { fetchRelationPages: true })
+  const recordMap = await notion.getPage(pageId)
 
   return {
     props: {

--- a/packages/notion-client/RELEASE.md
+++ b/packages/notion-client/RELEASE.md
@@ -1,0 +1,119 @@
+# Release Guide for @ahmedelkady/notion-client
+
+This guide covers how to release new versions of the `@ahmedelkady/notion-client` package.
+
+## Prerequisites
+
+1. **npm Authentication**: Make sure you're logged in to npm
+   ```bash
+   npm whoami  # Should show 'ahmedelkady'
+   ```
+
+2. **Dependencies Built**: Ensure workspace dependencies are built
+   ```bash
+   # From root directory
+   pnpm --filter notion-types build
+   pnpm --filter notion-utils build
+   ```
+
+## Release Process
+
+### 1. Prepare the Release
+
+```bash
+# Navigate to the package directory
+cd packages/notion-client
+
+# Install dependencies (if needed)
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run all tests
+pnpm test
+```
+
+### 2. Release New Version
+
+For different types of releases:
+
+**Patch Release** (7.3.0 → 7.3.1) - Bug fixes:
+```bash
+pnpm release:patch
+```
+
+**Minor Release** (7.3.0 → 7.4.0) - New features:
+```bash
+pnpm release:minor
+```
+
+**Major Release** (7.3.0 → 8.0.0) - Breaking changes:
+```bash
+pnpm release:major
+```
+
+### 3. Manual Release (Alternative)
+
+If you prefer manual control:
+
+```bash
+# 1. Update version manually
+npm version patch  # or minor/major
+
+# 2. Build
+pnpm build
+
+# 3. Test
+pnpm test
+
+# 4. Publish
+npm publish --access public
+```
+
+## Package Information
+
+- **Package Name**: `@ahmedelkady/notion-client`
+- **Current Version**: 7.3.0
+- **npm Registry**: https://www.npmjs.com/package/@ahmedelkady/notion-client
+- **Repository**: https://github.com/rimonhanna/react-notion-x
+
+## Dependencies
+
+This package depends on:
+- `notion-types` (workspace dependency)
+- `notion-utils` (workspace dependency)
+- `ky` (external)
+- `p-map` (external)
+
+## Troubleshooting
+
+### Build Errors
+If you get type errors, make sure dependencies are built:
+```bash
+cd ../../  # Go to root
+pnpm --filter notion-types build
+pnpm --filter notion-utils build
+cd packages/notion-client
+pnpm build
+```
+
+### Publish Errors
+- Ensure you're logged in: `npm whoami`
+- For scoped packages, use `--access public`
+- Check version conflicts on npm registry
+
+### Linting Errors
+Fix linting issues before publishing:
+```bash
+pnpm test:lint  # Check for issues
+# Fix manually or use IDE auto-fix
+```
+
+## Post-Release
+
+After publishing:
+1. Verify the package is available: https://www.npmjs.com/package/@ahmedelkady/notion-client
+2. Test installation: `npm install @ahmedelkady/notion-client`
+3. Update documentation if needed
+4. Consider tagging the Git commit: `git tag v7.3.1 && git push --tags` 

--- a/packages/notion-client/package.json
+++ b/packages/notion-client/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "notion-client",
+  "name": "@ahmedelkady/notion-client",
   "version": "7.3.0",
   "type": "module",
   "description": "Robust TypeScript client for the unofficial Notion API.",
-  "repository": "NotionX/react-notion-x",
+  "repository": "rimonhanna/react-notion-x",
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "license": "MIT",
   "main": "./build/index.js",
@@ -24,7 +24,10 @@
     "test": "run-s test:*",
     "test:lint": "eslint .",
     "test:typecheck": "tsc --noEmit",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "release:patch": "npm version patch && npm publish --access public",
+    "release:minor": "npm version minor && npm publish --access public",
+    "release:major": "npm version major && npm publish --access public"
   },
   "dependencies": {
     "ky": "^1.7.5",

--- a/packages/notion-client/package.json
+++ b/packages/notion-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tekunda/notion-client",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "type": "module",
   "description": "Robust TypeScript client for the unofficial Notion API.",
   "repository": "rimonhanna/react-notion-x",

--- a/packages/notion-client/package.json
+++ b/packages/notion-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ahmedelkady/notion-client",
+  "name": "@tekunda/notion-client",
   "version": "7.3.0",
   "type": "module",
   "description": "Robust TypeScript client for the unofficial Notion API.",

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -51,7 +51,7 @@ export class NotionAPI {
       signFileUrls = true,
       chunkLimit = 100,
       chunkNumber = 0,
-      fetchRelationPages = true, // New option
+      fetchRelationPages = false,
       kyOptions
     }: {
       concurrency?: number
@@ -60,7 +60,7 @@ export class NotionAPI {
       signFileUrls?: boolean
       chunkLimit?: number
       chunkNumber?: number
-      fetchRelationPages?: boolean // New option
+      fetchRelationPages?: boolean
       kyOptions?: KyOptions
     } = {}
   ): Promise<notion.ExtendedRecordMap> {

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -53,7 +53,7 @@ export class NotionAPI {
       chunkNumber = 0,
       fetchRelationPages = false,
       kyOptions,
-      embeddedFormBaseUrl
+      embeddedFormsBaseUrl
     }: {
       concurrency?: number
       fetchMissingBlocks?: boolean
@@ -63,7 +63,7 @@ export class NotionAPI {
       chunkNumber?: number
       fetchRelationPages?: boolean
       kyOptions?: KyOptions
-      embeddedFormBaseUrl?: string
+      embeddedFormsBaseUrl?: string
     } = {}
   ): Promise<notion.ExtendedRecordMap> {
     const page = await this.getPageRaw(pageId, {
@@ -210,8 +210,8 @@ export class NotionAPI {
       recordMap.block = { ...recordMap.block, ...newBlocks }
     }
 
-    if (embeddedFormBaseUrl) {
-      recordMap.embeddedFormBaseUrl = embeddedFormBaseUrl
+    if (embeddedFormsBaseUrl) {
+      recordMap.embeddedFormsBaseUrl = embeddedFormsBaseUrl
     }
 
     return recordMap

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -542,19 +542,9 @@ export class NotionAPI {
         }
       }
 
-      const reducerLabel = isBoardType ? 'board_columns' : `${type}_groups`
       loader = {
         type: 'reducer',
         reducers: {
-          [reducerLabel]: {
-            type: 'groups',
-            groupBy,
-            ...(collectionView?.query2?.filter && {
-              filter: collectionView?.query2?.filter
-            }),
-            groupSortPreference: groups.map((group: any) => group?.value),
-            limit
-          },
           ...reducersQuery
         },
         ...collectionView?.query2,

--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -52,7 +52,8 @@ export class NotionAPI {
       chunkLimit = 100,
       chunkNumber = 0,
       fetchRelationPages = false,
-      kyOptions
+      kyOptions,
+      embeddedFormBaseUrl
     }: {
       concurrency?: number
       fetchMissingBlocks?: boolean
@@ -62,6 +63,7 @@ export class NotionAPI {
       chunkNumber?: number
       fetchRelationPages?: boolean
       kyOptions?: KyOptions
+      embeddedFormBaseUrl?: string
     } = {}
   ): Promise<notion.ExtendedRecordMap> {
     const page = await this.getPageRaw(pageId, {
@@ -69,6 +71,7 @@ export class NotionAPI {
       chunkNumber,
       kyOptions
     })
+
     const recordMap = page?.recordMap as notion.ExtendedRecordMap
 
     if (!recordMap?.block) {
@@ -205,6 +208,10 @@ export class NotionAPI {
     if (fetchRelationPages) {
       const newBlocks = await this.fetchRelationPages(recordMap, kyOptions)
       recordMap.block = { ...recordMap.block, ...newBlocks }
+    }
+
+    if (embeddedFormBaseUrl) {
+      recordMap.embeddedFormBaseUrl = embeddedFormBaseUrl
     }
 
     return recordMap

--- a/packages/notion-compat/src/convert-rich-text.ts
+++ b/packages/notion-compat/src/convert-rich-text.ts
@@ -4,7 +4,7 @@ import type * as types from './types'
 import { convertColor } from './convert-color'
 
 export function convertRichText(richText: types.RichText): notion.Decoration[] {
-  return richText.map(convertRichTextItem).filter(Boolean)
+  return richText?.map(convertRichTextItem)?.filter(Boolean)
 }
 
 export function convertRichTextItem(

--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -44,6 +44,7 @@ export type BlockType =
   | 'external_object_instance'
   | 'breadcrumb'
   | 'miro'
+  | 'form'
   // fallback for unknown blocks
   | string
 
@@ -91,6 +92,7 @@ export type Block =
   | TableRowBlock
   | ExternalObjectInstance
   | BreadcrumbInstance
+  | FormBlock
 
 /**
  * Base properties shared by all blocks.
@@ -469,4 +471,20 @@ export interface ExternalObjectInstance extends BaseBlock {
 
 export interface BreadcrumbInstance extends BaseBlock {
   type: 'breadcrumb'
+}
+
+export interface FormBlock extends BaseBlock {
+  type: 'form'
+  format: {
+    site_id: string
+    form_config?: {
+      anonymous_submissions?: boolean
+      submission_permissions?: string
+    }
+    form_layout_pointer?: {
+      id: string
+      table: string
+      spaceId: string
+    }
+  }
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -14,6 +14,7 @@ import { AssetWrapper } from './components/asset-wrapper'
 import { Audio } from './components/audio'
 import { EOI } from './components/eoi'
 import { File } from './components/file'
+import { Form } from './components/form'
 import { GoogleDrive } from './components/google-drive'
 import { LazyImage } from './components/lazy-image'
 import { PageAside } from './components/page-aside'
@@ -763,6 +764,15 @@ export function Block(props: BlockProps) {
       if (!linkedBlock) {
         console.log('"alias" missing block', blockPointerId)
         return null
+      }
+
+      if ((linkedBlock as types.FormBlock)?.type === 'form') {
+        return (
+          <Form
+            block={linkedBlock}
+            embeddedFormBaseUrl={recordMap.embeddedFormBaseUrl}
+          />
+        )
       }
 
       return (

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -770,7 +770,7 @@ export function Block(props: BlockProps) {
         return (
           <Form
             block={linkedBlock}
-            embeddedFormBaseUrl={recordMap.embeddedFormBaseUrl}
+            embeddedFormsBaseUrl={recordMap.embeddedFormsBaseUrl}
           />
         )
       }

--- a/packages/react-notion-x/src/components/form.tsx
+++ b/packages/react-notion-x/src/components/form.tsx
@@ -1,15 +1,15 @@
 export function Form({
   block,
-  embeddedFormBaseUrl
+  embeddedFormsBaseUrl
 }: {
   block: any
-  embeddedFormBaseUrl: string
+  embeddedFormsBaseUrl: string
 }) {
   const formId = block?.id?.replace(/-/g, '')
   return (
     <iframe
       className='notion-form-iframe'
-      src={`${embeddedFormBaseUrl}/ebd/${formId}?theme=light`}
+      src={`${embeddedFormsBaseUrl}/ebd/${formId}?theme=light`}
       width='100%'
       height='600'
       allowFullScreen

--- a/packages/react-notion-x/src/components/form.tsx
+++ b/packages/react-notion-x/src/components/form.tsx
@@ -1,0 +1,19 @@
+export function Form({
+  block,
+  embeddedFormBaseUrl
+}: {
+  block: any
+  embeddedFormBaseUrl: string
+}) {
+  const formId = block?.id?.replace(/-/g, '')
+  return (
+    <iframe
+      className='notion-form-iframe'
+      src={`${embeddedFormBaseUrl}/ebd/${formId}?theme=light`}
+      width='100%'
+      height='600'
+      allowFullScreen
+      title={`Notion Form: ${block?.id}`}
+    />
+  )
+}

--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -151,7 +151,8 @@ const defaultNotionContext: NotionContext = {
     collection_view: {},
     collection_query: {},
     notion_user: {},
-    signed_urls: {}
+    signed_urls: {},
+    embeddedFormBaseUrl: ''
   },
 
   components: defaultComponents,

--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -152,7 +152,7 @@ const defaultNotionContext: NotionContext = {
     collection_query: {},
     notion_user: {},
     signed_urls: {},
-    embeddedFormBaseUrl: ''
+    embeddedFormsBaseUrl: ''
   },
 
   components: defaultComponents,


### PR DESCRIPTION
Thanks for the clarification! Here's a revised and professional version of your contribution note that reflects that the **user must provide the `embeddedFormBaseUrl`**, and the form is rendered inside an iframe with a custom class for styling:

---

#### ✨ Added Support for Notion Form Blocks

This PR adds support for rendering **Notion Form blocks** using a standard `<iframe>`, with a customizable embed source.

The user must provide the `embeddedFormBaseUrl` (e.g. a public Notion site like `https://tekunda.notion.site`) which is then used to generate the full form embed URL in the format:

```
[embeddedFormBaseUrl]/ebd/[formId]
```

The iframe is rendered with a `.notion-form-iframe` class to allow global styling and layout customization.

---

#### ✅ Example

```tsx
export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
  const recordMap = await notion.getPage(pageId, {
    fetchRelationPages: true,
    embeddedFormsBaseUrl: 'https://tekunda.notion.site'
  })

  if (previewImagesEnabled) {
    const previewImageMap = await getPreviewImageMap(recordMap)
    ;(recordMap as any).preview_images = previewImageMap
  }

  return recordMap
}
```

under the hood
```html
<iframe
  src="https://tekunda.notion.site/ebd/[formId]"
  class="notion-form-iframe"
  width="100%"
  height="600"
  allowfullscreen
/>
```

---

#### 🎯 Notes

* The embedded form inherits its theme (light/dark) from the Notion Site settings.
* This approach matches Notion’s native public site behavior.
* Developers can customize iframe appearance using `.notion-form-iframe` in global styles.

---

#### 🧪 Notion Test Page ID

```
cbd02f99163a4d6aa52db57cc426a7d0
```

---
