### PR TITLE
Fix for groups v2 api request issues

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -568,11 +568,18 @@ export class NotionAPI {
         reducers: {
           [reducerLabel]: {
             type: 'groups',
+            version: 'v2',
             groupBy,
             ...(collectionView?.query2?.filter && {
               filter: collectionView?.query2?.filter
             }),
-            groupSortPreference: groups.map((group: any) => group?.value),
+            groupSortPreference: groups.map((group: any) => ({
+              property: group?.property,
+              value: {
+                type: group?.value?.type,
+                value: group?.value?.value
+              }
+            })),
             limit
           },
           ...reducersQuery


### PR DESCRIPTION
#### Description

Fixes #650, #649, #648.

"Unofficial" Notion API changed its request shape! Particularly, it now requires `version = "v2"` and `groupSortPreference` slightly changed.


#### Notion Test Page ID
91c2be1a6018421ab9062e3f045eaa59

Before
<img width="2144" height="2334" alt="2025-07-23 at 00 56 47@2x" src="https://github.com/user-attachments/assets/76cadd7b-3261-4b6d-8335-f6978ef2dd80" />

After
<img width="2912" height="2334" alt="2025-07-23 at 00 56 26@2x" src="https://github.com/user-attachments/assets/cac2d57f-ff1a-478a-ba57-c78c7f108773" />
