### PR TITLE
Fix the bug of traversing collections

### DIFF
--- a/packages/notion-utils/src/get-all-pages-in-space.ts
+++ b/packages/notion-utils/src/get-all-pages-in-space.ts
@@ -108,8 +108,8 @@ export async function getAllPagesInSpace(
               page.collection_query
             )) {
               for (const collectionData of Object.values(collectionViews)) {
-                const { blockIds } = collectionData
-
+                const { blockIds } =
+                  collectionData?.collection_group_results || {}
                 if (blockIds) {
                   for (const collectionItemId of blockIds) {
                     void processPage(collectionItemId, depth + 1)


### PR DESCRIPTION
#### Description

The `getAllPagesInSpace()` function in `notion-utils` is valuable for sitemap generation and SSG. However, the current implementation fails to retrieve subpages within collections. This is because it searches for blockIds inside CollectionQueryResult, where the results are typically not present.

Upon investigation, I found that the relevant subpage data primarily resides in `CollectionQueryResult.collection_group_results`, not in the main CollectionQueryResult itself.

#### Notion Test Page ID

You can verify this behavior by logging the results during the build process.