### PR TITLE
Fix collection traverse

### DIFF
--- a/packages/notion-utils/src/get-all-pages-in-space.ts
+++ b/packages/notion-utils/src/get-all-pages-in-space.ts
@@ -108,8 +108,8 @@ export async function getAllPagesInSpace(
               page.collection_query
             )) {
               for (const collectionData of Object.values(collectionViews)) {
-                const { blockIds } = collectionData
-
+                const { blockIds } =
+                  collectionData?.collection_group_results || {}
                 if (blockIds) {
                   for (const collectionItemId of blockIds) {
                     void processPage(collectionItemId, depth + 1)

--- a/packages/react-notion-x/src/third-party/collection-utils.ts
+++ b/packages/react-notion-x/src/third-party/collection-utils.ts
@@ -34,7 +34,7 @@ export function getCollectionGroups(
       }
 
       // TODO: review dates format based on value.type ('week'|'month'|'year')
-      queryValue = format(new Date(queryLabel), 'MMM d, YYY hh:mm aa')
+      queryValue = format(new Date(queryLabel), 'MMM d, yyyy hh:mm aa')
     }
 
     return {

--- a/packages/react-notion-x/src/third-party/eval-formula.ts
+++ b/packages/react-notion-x/src/third-party/eval-formula.ts
@@ -300,7 +300,7 @@ function evalFunctionFormula(
 
         case 'object':
           if (value instanceof Date) {
-            return format(value as Date, 'MMM d, YYY')
+            return format(value as Date, 'MMM d, yyyy')
           } else {
             // shouldn't ever get here
             return `${value}`

--- a/packages/react-notion-x/src/third-party/property.tsx
+++ b/packages/react-notion-x/src/third-party/property.tsx
@@ -92,7 +92,7 @@ export function PropertyImpl(props: IPropertyProps) {
           }
 
           if (content instanceof Date) {
-            content = format(content, 'MMM d, YYY hh:mm aa')
+            content = format(content, 'MMM d, yyyy hh:mm aa')
           }
         } catch {
           // console.log('error evaluating formula', schema.formula, err)
@@ -437,7 +437,7 @@ export function PropertyImpl(props: IPropertyProps) {
   const renderCreatedTimeValue = React.useMemo(
     () =>
       function CreatedTimeProperty() {
-        return format(new Date(block!.created_time), 'MMM d, YYY hh:mm aa')
+        return format(new Date(block!.created_time), 'MMM d, yyyy hh:mm aa')
       },
     [block]
   )
@@ -445,7 +445,7 @@ export function PropertyImpl(props: IPropertyProps) {
   const renderLastEditedTimeValue = React.useMemo(
     () =>
       function LastEditedTimeProperty() {
-        return format(new Date(block!.last_edited_time), 'MMM d, YYY hh:mm aa')
+        return format(new Date(block!.last_edited_time), 'MMM d, yyyy hh:mm aa')
       },
     [block]
   )


### PR DESCRIPTION
#### Description

The `getAllPagesInSpace()` function in `notion-utils` is valuable for sitemap generation and SSG. However, the current implementation fails to retrieve subpages within collections. This is because it searches for `blockIds` inside `CollectionQueryResult`, where the results are typically not present.

Upon investigation, I found that the relevant subpage data primarily resides in `CollectionQueryResult.collection_group_results`, not in the main `CollectionQueryResult` itself.

BTW, I fixed #616 to remove annoying warnings during building.
 
#### Notion Test Page ID

You can verify this behavior by logging the results during the build process.