### PR TITLE
fix: update endpoint in getBlocks method to syncRecordValuesMain

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -649,7 +649,7 @@ export class NotionAPI {
 
   public async getBlocks(blockIds: string[], kyOptions?: KyOptions) {
     return this.fetch<notion.PageChunk>({
-      endpoint: 'syncRecordValues',
+      endpoint: 'syncRecordValuesMain',
       body: {
         requests: blockIds.map((blockId) => ({
           // TODO: when to use table 'space' vs 'block'?


### PR DESCRIPTION
#### Description

`getBlocks` uses `syncRecordValues` endpoint which is now deperecated and no longer works unfortunatly. This PR update that to the working endpoint `syncRecordValuesMain` 
Related to #659 (suggest `beforeRequest` hook) and #661 (suggest package patching)

#### Notion Test Page ID

0fa06897b70f4e78876324cd9df76356