### PR TITLE
Fix TOC extraction for headings inside Notion columns (column_list / column)

### DIFF
--- a/packages/notion-utils/src/get-page-table-of-contents.ts
+++ b/packages/notion-utils/src/get-page-table-of-contents.ts
@@ -47,7 +47,11 @@ export const getPageTableOfContents = (
           }
         }
 
-        if (type === 'transclusion_container') {
+        if (
+          type === 'transclusion_container' ||
+          type === 'column_list' ||
+          type === 'column'
+        ) {
           return mapContentToEntries(block.content)
         }
       }
@@ -56,10 +60,15 @@ export const getPageTableOfContents = (
     })
   }
 
-  const toc = mapContentToEntries(page.content)
-    // Synced blocks cannot be nested. So theoretically a 1-level flattening is enough.
-    .flat()
-    .filter(Boolean) as Array<TableOfContentsEntry>
+  // Helper function to flatten nested results recursively
+  function flattenResults(results: MapResult[]): TableOfContentsEntry[] {
+    return results.flatMap((r) => {
+      if (r == null) return []
+      return Array.isArray(r) ? flattenResults(r) : [r]
+    })
+  }
+
+  const toc = flattenResults(mapContentToEntries(page.content))
 
   const indentLevelStack = [
     {


### PR DESCRIPTION
## Summary
`react-notion-x` builds the Table of Contents (TOC) by scanning page blocks and extracting heading blocks (H1/H2/H3).  
Currently, headings placed inside Notion column layouts (`column_list` -> `column`) are not reliably discovered, which results in incomplete TOC output.

This PR updates the TOC traversal logic to:
- recurse into column container blocks (`column_list` / `column`), and
- flatten nested traversal results recursively (instead of a 1-level `.flat()`).

As a result, TOC extraction works consistently for:
- user-defined Notion `table_of_contents` blocks (custom placement), and
- the library built-in TOC feature (`showTableOfContents={true}`).

---

## Problem / Impact
### What breaks
This bug affects **two entry points** in the library:

1. **Rendering a Notion `table_of_contents` block**  
   When a user manually adds a `table_of_contents` block to place TOC in a custom location, the renderer hits:
   - `case 'table_of_contents'` -> `getPageTableOfContents(...)`  
   If headings are inside columns, the TOC does not include them.
<img width="1347" height="462" alt="image" src="https://github.com/user-attachments/assets/d4e9d13f-9ccb-42f6-8514-ca8a07c83867" />
   where `getPageTableOfContents` is called in the `table_of_contents` rendering path.

2. **Library-provided TOC (`showTableOfContents={true}`)**  
   The built-in TOC feature also relies on the same TOC extraction function, so headings inside columns are missing there as well.

### Why it matters
Column layouts are a common Notion pattern for documentation-like pages, and missing headings makes TOC navigation unreliable.

## Root cause analysis

### 1) Traversal does not recurse into column containers
Previously, `mapContentToEntries` only recursed into `transclusion_container`.
```ts
if (type === 'transclusion_container') {
  return mapContentToEntries(block.content)
}
```
In Notion, column layouts are represented by container blocks:
- `column_list` contains `column` blocks
- `column` contains actual content blocks (including headings)

Without recursing into these container types, headings inside columns are never visited, so they are missing from the extracted TOC.

### 2) Flattening assumes max 1 nesting level
TOC entries were flattened using a one-level flatten approach. This works only if the traversal result is nested at most one level deep:
```ts
const toc = mapContentToEntries(page.content)
  // Synced blocks cannot be nested. So theoretically a 1-level flattening is enough.
  .flat()
  .filter(Boolean) as Array<TableOfContentsEntry>
```

After adding recursion into column containers, the traversal result can be nested deeper than one level (e.g., page -> column_list -> column -> blocks). In that case, a one-level flatten is insufficient and can leave nested arrays unprocessed, which results in missing TOC entries.

---

## Fix

### 1) Recurse into `column_list` and `column`
Extend the recursion condition so that the traversal also descends into:
- `column_list`
- `column`
(in addition to `transclusion_container`)

This ensures headings inside columns are included in the traversal.
```ts
if (
  type === 'transclusion_container' ||
  type === 'column_list' ||
  type === 'column'
) {
  return mapContentToEntries(block.content)
}
```
### 2) Flatten recursively (instead of one-level flatten)
Replace the one-level flattening step with a recursive flattening approach so that TOC entries are collected correctly regardless of nesting depth introduced by column layouts.
```ts
// Helper function to flatten nested results recursively
function flattenResults(results: MapResult[]): TableOfContentsEntry[] {
  return results.flatMap((r) => {
    if (r == null) return []
    return Array.isArray(r) ? flattenResults(r) : [r]
  })
}

const toc = flattenResults(mapContentToEntries(page.content))
```

## Compatibility / Risk assessment
- **Backwards compatible:** pages without columns keep the same behavior.
- **More robust:** supports deeper nesting (columns, synced blocks, etc.) without relying on a 1-level flatten assumption.
- **No rendering changes:** only affects TOC extraction.

## Example
### Notion page setup
<img width="1163" height="944" alt="image" src="https://github.com/user-attachments/assets/19bbd671-b837-4a2e-be32-8a7543f2aeef" />

### Result before fix
<img width="1093" height="942" alt="image" src="https://github.com/user-attachments/assets/e4a78549-c34b-4596-8f4d-cf712425dc80" />

### Result after fix
<img width="1165" height="910" alt="image" src="https://github.com/user-attachments/assets/3f30f277-828a-4471-8def-bd28c8ba3ca9" />
