### PR TITLE
fix: filters ghost tags (i.e., not in schema)

### DIFF
--- a/packages/react-notion-x/src/third-party/property.tsx
+++ b/packages/react-notion-x/src/third-party/property.tsx
@@ -525,7 +525,10 @@ export function PropertyImpl(props: IPropertyProps) {
       case 'select':
       // intentional fallthrough
       case 'multi_select': {
-        const values = (data?.[0]?.[0] || '').split(',')
+        const originalValues = (data?.[0]?.[0] || '').split(',')
+        const values = originalValues.filter((value) =>
+          schema.options?.some((option) => value === option.value)
+        )
 
         content = values.map((value, index) => {
           const option = schema.options?.find(


### PR DESCRIPTION
#### Description

Fix: "Ghost" Tag Filtering
**Context**: Users observed tags (e.g., "Report") appearing in collection items that did not exist in the collection's schema. This indicates stale data in the item's properties that was deleted from the global schema but not the individual blocks.

-   **Rationale**: The UI should only display valid, defined tags to ensure consistency.
-   **Implementation**: 
    -   Modified `PropertyImpl` in `packages/react-notion-x/src/third-party/property.tsx`.
    -   For `select` and `multi_select` types, the code now filters the item's property values against the valid options defined in `collection.schema`.
    -   Any value not found in the schema is silently discarded during rendering.

#### Notion Test Page ID

1a739459e28a4e8084556a5ef518c009

Check the tags of the News collection. For some items it will show a ghost "Report" tag that is not in the schema.  