### PR TITLE
feat: add button block support with automation actions

### DIFF
--- a/examples/minimal/lib/config.ts
+++ b/examples/minimal/lib/config.ts
@@ -1,5 +1,6 @@
 // TODO: change this to the notion ID of the page you want to test
-export const rootNotionPageId = '067dd719a912471ea9a3ac10710e7fdf'
+// my example notion page implementing buttons https://www.notion.so/Notion-API-Testing-Page-30a2598df29f8002ac30fdbb98ae3eb5
+export const rootNotionPageId = '30a2598df29f8002ac30fdbb98ae3eb5'
 
 // NOTE: rootNotionSpaceId is optional; set it to undefined if you don't want to
 // use it.

--- a/examples/minimal/pages/api/webhook-proxy.ts
+++ b/examples/minimal/pages/api/webhook-proxy.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const { url, payload, headers } = req.body
+
+    if (!url || !payload) {
+      return res.status(400).json({ error: 'Missing url or payload' })
+    }
+
+    // Forward the request to the actual webhook URL
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers
+      },
+      body: JSON.stringify(payload)
+    })
+
+    const responseData = await response.text()
+
+    // Return the response from the webhook
+    return res.status(response.status).json({
+      success: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      data: responseData
+    })
+  } catch (err) {
+    console.error('Webhook proxy error:', err)
+    return res.status(500).json({
+      error: 'Failed to forward webhook',
+      message: err instanceof Error ? err.message : 'Unknown error'
+    })
+  }
+}

--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -43,6 +43,7 @@ export type BlockType =
   | 'table_row'
   | 'external_object_instance'
   | 'breadcrumb'
+  | 'button'
   | 'miro'
   // fallback for unknown blocks
   | string
@@ -91,6 +92,7 @@ export type Block =
   | TableRowBlock
   | ExternalObjectInstance
   | BreadcrumbInstance
+  | ButtonBlock
 
 /**
  * Base properties shared by all blocks.
@@ -276,6 +278,17 @@ export interface ToggleBlock extends BaseBlock {
   type: 'toggle'
   properties: {
     title: Decoration[]
+  }
+}
+
+export interface ButtonBlock extends BaseBlock {
+  type: 'button'
+  format?: {
+    block_color?: Color
+    automation_id?: string
+  }
+  properties?: {
+    title?: Decoration[]
   }
 }
 

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -12,6 +12,7 @@ import React from 'react'
 
 import { AssetWrapper } from './components/asset-wrapper'
 import { Audio } from './components/audio'
+import { Button } from './components/button'
 import { EOI } from './components/eoi'
 import { File } from './components/file'
 import { GoogleDrive } from './components/google-drive'
@@ -727,6 +728,18 @@ export function Block(props: BlockProps) {
           <div>{children}</div>
         </details>
       )
+
+    case 'button': {
+      const ButtonComponent = components.Button || Button
+
+      return (
+        <ButtonComponent
+          blockId={blockId}
+          block={block as types.ButtonBlock}
+          className={blockId}
+        />
+      )
+    }
 
     case 'table_of_contents': {
       const page = getBlockParentPage(block, recordMap)

--- a/packages/react-notion-x/src/components/button.tsx
+++ b/packages/react-notion-x/src/components/button.tsx
@@ -1,0 +1,329 @@
+import type * as types from 'notion-types'
+import React from 'react'
+
+import { useNotionContext } from '../context'
+import { cs } from '../utils'
+import { Text } from './text'
+
+interface AutomationValue {
+  id: string
+  action_ids: string[]
+  properties?: {
+    name?: string
+    icon?: string
+  }
+  trigger?: {
+    type: string
+  }
+}
+
+interface AutomationActionValue {
+  id: string
+  type: 'open_page' | 'send_webhook' | 'http_request' | string
+  config?: {
+    target?: {
+      type?: 'url' | 'page'
+      url?: string
+      pageId?: string
+    }
+    url?: string
+    method?: string
+    headers?: Record<string, string>
+    body?: string
+    apiVersion?: string
+    customHeaders?: Array<{
+      id: string
+      key: string
+      value: string
+    }>
+  }
+}
+
+export function Button({
+  block,
+  blockId,
+  className
+}: {
+  blockId: string
+  block: types.ButtonBlock
+  className?: string
+}) {
+  const { recordMap, mapPageUrl } = useNotionContext()
+  const [isSuccess, setIsSuccess] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  if (!block || block.type !== 'button') {
+    console.warn('Invalid button block:', { block })
+    return null
+  }
+
+  // Get automation ID from block format
+  const automationId = block.format?.automation_id
+
+  // Get button text and color
+  const blockColor = block.format?.block_color || 'default'
+  const title = block.properties?.title
+
+  // If no automation, render a simple static button
+  if (!automationId) {
+    return (
+      <div className={cs('notion-button-block', blockId)}>
+        <button
+          type='button'
+          className={cs('notion-button', `notion-${blockColor}`, className)}
+        >
+          {title ? <Text value={title} block={block} /> : 'Button'}
+        </button>
+      </div>
+    )
+  }
+
+  // Get automation data
+  const automation = (recordMap as any).automation?.[automationId]?.value as
+    | AutomationValue
+    | undefined
+
+  if (!automation) {
+    // Fallback to title if no automation found
+    const buttonText = title ? getTextContent(title) : 'Button'
+    return (
+      <div className={cs('notion-button-block', blockId)}>
+        <button
+          type='button'
+          className={cs('notion-button', `notion-${blockColor}`, className)}
+        >
+          {buttonText}
+        </button>
+      </div>
+    )
+  }
+
+  // Get button text from automation properties or fall back to title
+  const buttonText =
+    automation.properties?.name || (title ? getTextContent(title) : 'Button')
+
+  // Handle button click - execute the first action
+  const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault()
+
+    if (isLoading) return
+
+    setIsSuccess(false)
+    setIsLoading(true)
+
+    try {
+      await executeAction()
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const executeAction = async () => {
+    // Get the first action
+    const firstActionId = automation.action_ids?.[0]
+    if (!firstActionId) {
+      console.warn('No actions defined for automation:', automationId)
+      return
+    }
+
+    const actionData = (recordMap as any).automation_action?.[firstActionId]
+      ?.value as AutomationActionValue | undefined
+    if (!actionData) {
+      console.warn('No action data found for ID:', firstActionId)
+      return
+    }
+
+    // Execute action based on type
+    switch (actionData.type) {
+      case 'open_page': {
+        // Handle open_page action
+        const target = actionData.config?.target
+        if (target?.type === 'url' && target.url) {
+          // Open URL in new tab
+          window.open(target.url, '_blank', 'noopener,noreferrer')
+        } else if (target?.type === 'page' && target.pageId) {
+          // Navigate to Notion page using mapPageUrl
+          const pageUrl = mapPageUrl(target.pageId)
+          if (pageUrl) {
+            window.location.href = pageUrl
+          }
+        }
+        break
+      }
+
+      case 'send_webhook':
+      case 'http_request': {
+        // Handle webhook action - requires custom webhook proxy
+        const webhookUrl = actionData.config?.url?.trim()
+        if (webhookUrl) {
+          try {
+            // Try to use webhook proxy if available
+            if (typeof window !== 'undefined' && '/api/webhook-proxy') {
+              const pageBlockId = Object.keys(recordMap.block || {}).find(
+                (id) => {
+                  const b = recordMap.block[id]?.value
+                  return b && 'type' in b && b.type === 'page'
+                }
+              )
+              const pageBlock = pageBlockId
+                ? (recordMap.block[pageBlockId]?.value as any)
+                : null
+
+              if (!pageBlock) {
+                console.warn('No page block found for webhook payload')
+                return
+              }
+
+              // Build Notion-style webhook payload
+              const payload = {
+                source: {
+                  type: 'automation',
+                  automation_id: automationId,
+                  action_id: actionData.id,
+                  event_id: crypto.randomUUID(),
+                  user_id: pageBlock.created_by_id || 'unknown',
+                  attempt: 1
+                },
+                data: {
+                  object: 'page',
+                  id: pageBlock.id,
+                  created_time: new Date(pageBlock.created_time).toISOString(),
+                  last_edited_time: new Date(
+                    pageBlock.last_edited_time
+                  ).toISOString(),
+                  created_by: {
+                    object: 'user',
+                    id: pageBlock.created_by_id || 'unknown'
+                  },
+                  last_edited_by: {
+                    object: 'user',
+                    id: pageBlock.last_edited_by_id || 'unknown'
+                  },
+                  cover: pageBlock.format?.page_cover
+                    ? {
+                        type: 'external',
+                        external: {
+                          url: pageBlock.format.page_cover.startsWith('/')
+                            ? `https://www.notion.so${pageBlock.format.page_cover}`
+                            : pageBlock.format.page_cover
+                        }
+                      }
+                    : null,
+                  icon: pageBlock.format?.page_icon
+                    ? {
+                        type: 'external',
+                        external: { url: pageBlock.format.page_icon }
+                      }
+                    : null,
+                  parent: {
+                    type: 'workspace',
+                    workspace: true
+                  },
+                  archived: !pageBlock.alive,
+                  in_trash: false,
+                  is_locked: false,
+                  properties: {
+                    title: {
+                      id: 'title',
+                      type: 'title',
+                      title: pageBlock.properties?.title
+                        ? pageBlock.properties.title.map((t: any) => {
+                            const text = typeof t === 'string' ? t : t[0] || ''
+                            return {
+                              type: 'text',
+                              text: { content: text, link: null },
+                              annotations: {
+                                bold: false,
+                                italic: false,
+                                strikethrough: false,
+                                underline: false,
+                                code: false,
+                                color: 'default'
+                              },
+                              plain_text: text,
+                              href: null
+                            }
+                          })
+                        : []
+                    }
+                  },
+                  url: `https://www.notion.so/${pageBlock.id}`,
+                  public_url: window.location.href,
+                  request_id: crypto.randomUUID()
+                }
+              }
+
+              // Build headers from customHeaders array
+              const headers: Record<string, string> = {
+                'Content-Type': 'application/json'
+              }
+              if (actionData.config?.customHeaders) {
+                for (const header of actionData.config.customHeaders) {
+                  headers[header.key] = header.value
+                }
+              }
+
+              console.log('Sending webhook:', {
+                url: webhookUrl,
+                payload,
+                headers
+              })
+
+              // Send through proxy API to avoid CORS issues
+              const response = await fetch('/api/webhook-proxy', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ url: webhookUrl, payload, headers })
+              })
+
+              const result = await response.json()
+
+              if (!response.ok || !result.success) {
+                console.error('Webhook request failed:', result)
+              } else {
+                console.log('Webhook sent successfully:', result)
+                setIsSuccess(true)
+                setTimeout(() => setIsSuccess(false), 2000)
+              }
+            } else {
+              console.warn(
+                'Webhook functionality requires /api/webhook-proxy endpoint'
+              )
+            }
+          } catch (err) {
+            console.error('Error sending webhook:', err)
+          }
+        }
+        break
+      }
+
+      default:
+        console.warn('Unsupported action type:', actionData.type)
+    }
+  }
+
+  return (
+    <div className={cs('notion-button-block', blockId)}>
+      <button
+        type='button'
+        className={cs(
+          'notion-button',
+          `notion-${blockColor}`,
+          isSuccess ? 'notion-success' : '',
+          className
+        )}
+        onClick={handleClick}
+        title={buttonText}
+        disabled={isLoading}
+      >
+        {buttonText}
+      </button>
+    </div>
+  )
+}
+
+function getTextContent(text: types.Decoration[]): string {
+  return text.map((t) => (typeof t === 'string' ? t : t[0] || '')).join('')
+}

--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -112,6 +112,7 @@ const defaultComponents: NotionComponents = {
   PageLink: DefaultPageLinkMemo,
   Checkbox: DefaultCheckbox,
   Callout: undefined, // use the built-in callout rendering by default
+  Button: undefined, // use the built-in button rendering by default
 
   Code: dummyComponent('Code'),
   Equation: dummyComponent('Equation'),

--- a/packages/react-notion-x/src/index.ts
+++ b/packages/react-notion-x/src/index.ts
@@ -1,3 +1,4 @@
+export * from './components/button'
 export * from './components/header'
 export * from './components/page-icon'
 export * from './components/text'

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1227,6 +1227,287 @@ svg.notion-page-icon {
   margin-left: 1.1em;
 }
 
+.notion-button-block {
+  padding: 4px 0;
+  margin: 4px 0;
+}
+
+.notion-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border: 1px solid var(--notion-gray);
+  border-radius: 3px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #000;
+  background-color: transparent;
+  cursor: pointer;
+  min-height: 32px;
+  transition: background-color 0.15s ease;
+}
+
+.notion-button:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.notion-button:active {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.notion-button:focus-visible {
+  outline: 2px solid var(--fg-color);
+  outline-offset: 2px;
+}
+
+.notion-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Button color variants using Notion's item colors */
+.notion-button-inner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.2;
+  padding: 6px 12px;
+  border: 1px solid transparent;
+  min-height: 32px;
+  transition: background-color 0.15s ease;
+  color: #000;
+}
+
+.notion-button-inner:hover {
+  filter: brightness(0.95);
+}
+
+.notion-button-inner:active {
+  filter: brightness(0.9);
+}
+
+.notion-button-inner:focus-visible {
+  outline: 2px solid var(--fg-color);
+  outline-offset: 2px;
+}
+
+.notion-button-inner:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Blue variant */
+.notion-blue_background .notion-button-inner,
+.notion-button.notion-blue_background {
+  background-color: var(--notion-item-blue);
+  border-color: var(--notion-item-blue);
+}
+
+.notion-button.notion-blue_background:hover {
+  background-color: var(--notion-item-blue);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-blue_background:active {
+  background-color: var(--notion-item-blue);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Red variant */
+.notion-red_background .notion-button-inner,
+.notion-button.notion-red_background {
+  background-color: var(--notion-item-red);
+  border-color: var(--notion-item-red);
+}
+
+.notion-button.notion-red_background:hover {
+  background-color: var(--notion-item-red);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-red_background:active {
+  background-color: var(--notion-item-red);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Orange variant */
+.notion-orange_background .notion-button-inner,
+.notion-button.notion-orange_background {
+  background-color: var(--notion-item-orange);
+  border-color: var(--notion-item-orange);
+}
+
+.notion-button.notion-orange_background:hover {
+  background-color: var(--notion-item-orange);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-orange_background:active {
+  background-color: var(--notion-item-orange);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Green/Teal variant */
+.notion-green_background .notion-button-inner,
+.notion-teal_background .notion-button-inner,
+.notion-button.notion-green_background,
+.notion-button.notion-teal_background {
+  background-color: var(--notion-item-green);
+  border-color: var(--notion-item-green);
+}
+
+.notion-button.notion-green_background:hover,
+.notion-button.notion-teal_background:hover {
+  background-color: var(--notion-item-green);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-green_background:active,
+.notion-button.notion-teal_background:active {
+  background-color: var(--notion-item-green);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Yellow variant */
+.notion-yellow_background .notion-button-inner,
+.notion-button.notion-yellow_background {
+  background-color: var(--notion-item-yellow);
+  border-color: var(--notion-item-yellow);
+}
+
+.notion-button.notion-yellow_background:hover {
+  background-color: var(--notion-item-yellow);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-yellow_background:active {
+  background-color: var(--notion-item-yellow);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Purple variant */
+.notion-purple_background .notion-button-inner,
+.notion-button.notion-purple_background {
+  background-color: var(--notion-item-purple);
+  border-color: var(--notion-item-purple);
+}
+
+.notion-button.notion-purple_background:hover {
+  background-color: var(--notion-item-purple);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-purple_background:active {
+  background-color: var(--notion-item-purple);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Pink variant */
+.notion-pink_background .notion-button-inner,
+.notion-button.notion-pink_background {
+  background-color: var(--notion-item-pink);
+  border-color: var(--notion-item-pink);
+}
+
+.notion-button.notion-pink_background:hover {
+  background-color: var(--notion-item-pink);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-pink_background:active {
+  background-color: var(--notion-item-pink);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Gray variant */
+.notion-gray_background .notion-button-inner,
+.notion-button.notion-gray_background {
+  background-color: var(--notion-item-gray);
+  border-color: var(--notion-item-gray);
+}
+
+.notion-button.notion-gray_background:hover {
+  background-color: var(--notion-item-gray);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-gray_background:active {
+  background-color: var(--notion-item-gray);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Brown variant */
+.notion-brown_background .notion-button-inner,
+.notion-button.notion-brown_background {
+  background-color: var(--notion-item-brown);
+  border-color: var(--notion-item-brown);
+}
+
+.notion-button.notion-brown_background:hover {
+  background-color: var(--notion-item-brown);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-brown_background:active {
+  background-color: var(--notion-item-brown);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Default variant */
+.notion-button.notion-default {
+  background-color: var(--notion-item-default);
+  border-color: var(--notion-gray);
+}
+
+.notion-button.notion-default:hover {
+  background-color: var(--notion-item-default);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.04);
+}
+
+.notion-button.notion-default:active {
+  background-color: var(--notion-item-default);
+  box-shadow: inset 0 0 0 2000px rgba(0, 0, 0, 0.08);
+}
+
+/* Success state - darker green */
+.notion-button.notion-success {
+  background-color: rgb(175, 210, 175) !important;
+  border-color: rgb(175, 210, 175) !important;
+}
+
+.notion-button.notion-default:hover {
+  background-color: var(--fg-color-1);
+}
+
+/* Success state */
+.notion-button.notion-success,
+.notion-button-inner.notion-success {
+  background-color: #0f7b6c !important;
+  color: white !important;
+}
+
+.notion-button.notion-success:hover,
+.notion-button-inner.notion-success:hover {
+  background-color: #0a5f54 !important;
+}
+
+/* Dark mode adjustments */
+.dark-mode .notion-button,
+.dark-mode .notion-button-inner {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.dark-mode .notion-button:hover,
+.dark-mode .notion-button-inner:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
 .notion-collection {
   align-self: center;
   min-width: 100%;

--- a/packages/react-notion-x/src/types.ts
+++ b/packages/react-notion-x/src/types.ts
@@ -29,6 +29,11 @@ export interface NotionComponents {
   Code: any
   Equation: any
   Callout?: any
+  Button?: React.ComponentType<{
+    blockId: string
+    block: types.ButtonBlock
+    className?: string
+  }>
 
   // collection
   Collection: any

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,55 @@ For `Equation` support, you'll need to import the katex CSS styles.
 
 For each of these optional components, make sure you're also importing the relevant third-party CSS if needed ([above](#Styles)).
 
+### Custom Button Components
+
+Button blocks are rendered by default using a simple built-in implementation that displays the button text with proper colors. For advanced functionality like handling button clicks with automations (opening URLs, triggering webhooks), you can provide a custom `Button` component:
+
+```tsx
+import { NotionButton } from './components/NotionButton'
+
+export default ({ recordMap }) => (
+  <NotionRenderer
+    recordMap={recordMap}
+    components={{
+      Button: NotionButton
+    }}
+  />
+)
+```
+
+## Custom Button Components
+
+Button blocks are now **built-in by default** with full automation support including:
+
+- Opening external URLs in new tabs
+- Internal page navigation
+- Sending webhooks with Notion-format payloads
+- Custom header support
+
+The default Button component is exported from `react-notion-x` and handles most common use cases automatically. If you need custom behavior, you can override it:
+
+```tsx
+import { Button } from 'react-notion-x'
+
+// Optional: Create a custom button component
+const MyCustomButton = ({ blockId, block, className }) => {
+  // Your custom implementation
+  return <Button blockId={blockId} block={block} className={className} />
+}
+
+<NotionRenderer
+  recordMap={recordMap}
+  components={{
+    Button: MyCustomButton
+  }}
+/>
+```
+
+For webhook functionality, you'll need a server-side proxy endpoint to avoid CORS issues. See [examples/minimal/pages/api/webhook-proxy.ts](./examples/minimal/pages/api/webhook-proxy.ts) for a Next.js implementation.
+
+The Button component receives `blockId`, `block`, and optional `className` as props. See [packages/react-notion-x/src/components/button.tsx](./packages/react-notion-x/src/components/button.tsx) for the default implementation.
+
 ## Private Pages
 
 You may optionally pass an `authToken` and `activeUser` to the API if you want to access private Notion pages. Both can be retrieved from your web browser. Once you are viewing your workpace, open your Development Tools > Application > Cookie > and Copy the `token_v2` and `notion_user_id`. Respectively, activeUser: notion_user_id, authToken: token_v2.
@@ -224,6 +273,7 @@ The majority of Notion blocks and collection views are fully supported.
 | Column                   | ✅ Yes     | `column`               |
 | Column List              | ✅ Yes     | `column_list`          |
 | Toggle                   | ✅ Yes     | `toggle`               | [`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)                                 |
+| Button                   | ✅ Yes     | `button`               | Interactive buttons with automation support (open URLs, webhooks) - customizable via components prop             |
 | Image                    | ✅ Yes     | `image`                | `<img>`                                                                                                          |
 | Embed                    | ✅ Yes     | `embed`                | Generic `iframe` embeds                                                                                          |
 | Video                    | ✅ Yes     | `video`                | `iframe`                                                                                                         |


### PR DESCRIPTION
Implements button blocks with full automation support:

- **open_page**: Navigate to URLs (internal/external)
- **send_webhook**: POST JSON to webhook endpoints  
- **http_request**: Execute HTTP requests with custom bodies

Includes minimal CSS styling matching Notion's design:
- Thin font (400), grey borders, pastel backgrounds
- Hover/active states with box-shadow overlays




- 2s success state with green feedback

Built-in component exported from react-notion-x package.

# DEMO VIDEO
https://github.com/user-attachments/assets/5c69f959-24f1-4aa1-bb7a-0777440b4165