### PR TITLE
fix: remove manual width/padding calculations from collection views

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1519,6 +1519,8 @@ svg.notion-page-icon {
 .notion-collection {
   align-self: center;
   min-width: 100%;
+  max-width: 100%;
+  overflow: auto;
 }
 
 .notion-collection-header {

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1583,8 +1583,8 @@ svg.notion-page-icon {
 }
 
 .notion-table {
-  width: 100vw;
-  max-width: 100vw;
+  width: 100%;
+  max-width: 100%;
   align-self: center;
   overflow: auto hidden;
 }
@@ -2027,8 +2027,8 @@ svg.notion-page-icon {
 }
 
 .notion-board {
-  width: 100vw;
-  max-width: 100vw;
+  width: 100%;
+  max-width: 100%;
   align-self: center;
   overflow: auto hidden;
 }

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1521,6 +1521,8 @@ svg.notion-page-icon {
   min-width: 100%;
   max-width: 100%;
   overflow: auto;
+  padding: 4px;
+  margin: -4px;
 }
 
 .notion-collection-header {

--- a/packages/react-notion-x/src/third-party/collection.tsx
+++ b/packages/react-notion-x/src/third-party/collection.tsx
@@ -17,9 +17,7 @@ import { CollectionViewIcon } from '../icons/collection-view-icon'
 import { cs } from '../utils'
 import { CollectionRow } from './collection-row'
 import { CollectionView } from './collection-view'
-import { useLocalStorage, useWindowSize } from './react-use'
-
-const isServer = !globalThis.window
+import { useLocalStorage } from './react-use'
 
 export function Collection({
   block,
@@ -27,9 +25,9 @@ export function Collection({
   ctx
 }: {
   block:
-    | types.CollectionViewBlock
-    | types.CollectionViewPageBlock
-    | types.PageBlock
+  | types.CollectionViewBlock
+  | types.CollectionViewPageBlock
+  | types.PageBlock
   className?: string
   ctx: NotionContext
 }) {
@@ -116,10 +114,10 @@ function CollectionViewBlock({
     [collectionState, setCollectionState]
   )
 
-  let { width: windowWidth } = useWindowSize()
-  if (isServer) {
-    windowWidth = 1024
-  }
+  // let { width: windowWidth } = useWindowSize()
+  // if (isServer) {
+  //   windowWidth = 1024
+  // }
 
   const collection = getBlockValue(recordMap.collection[collectionId])
   const collectionView = getBlockValue(
@@ -127,44 +125,48 @@ function CollectionViewBlock({
   )
   const collectionData =
     recordMap.collection_query[collectionId]?.[collectionViewId]
-  const parentPage = getBlockParentPage(block, recordMap)
+  // const parentPage = getBlockParentPage(block, recordMap)
 
   const { width, padding } = React.useMemo(() => {
     const style: React.CSSProperties = {}
 
-    if (collectionView?.type !== 'table' && collectionView?.type !== 'board') {
-      return {
-        style,
-        width: 0,
-        padding: 0
-      }
-    }
+    // The logic below was forcing window-relative centering which breaks when
+    // the collection is inside a constrained container (standard Notion page).
+    // Relying on CSS layout is safer.
 
-    const width = windowWidth
-    // TODO: customize for mobile?
-    const maxNotionBodyWidth = 708
-    let notionBodyWidth = maxNotionBodyWidth
+    // if (collectionView?.type !== 'table' && collectionView?.type !== 'board') {
+    //   return {
+    //     style,
+    //     width: 0,
+    //     padding: 0
+    //   }
+    // }
 
-    if (parentPage?.format?.page_full_width) {
-      notionBodyWidth = Math.trunc(width - 2 * Math.min(96, width * 0.08))
-    } else {
-      notionBodyWidth =
-        width < maxNotionBodyWidth
-          ? Math.trunc(width - width * 0.02) // 2vw
-          : maxNotionBodyWidth
-    }
+    // const width = windowWidth
+    // // TODO: customize for mobile?
+    // const maxNotionBodyWidth = 708
+    // let notionBodyWidth = maxNotionBodyWidth
 
-    const padding =
-      isServer && !isMounted ? 96 : Math.trunc((width - notionBodyWidth) / 2)
-    style.paddingLeft = padding
-    style.paddingRight = padding
+    // if (parentPage?.format?.page_full_width) {
+    //   notionBodyWidth = Math.trunc(width - 2 * Math.min(96, width * 0.08))
+    // } else {
+    //   notionBodyWidth =
+    //     width < maxNotionBodyWidth
+    //       ? Math.trunc(width - width * 0.02) // 2vw
+    //       : maxNotionBodyWidth
+    // }
+
+    // const padding =
+    //   isServer && !isMounted ? 96 : Math.trunc((width - notionBodyWidth) / 2)
+    // style.paddingLeft = padding
+    // style.paddingRight = padding
 
     return {
       style,
-      width,
-      padding
+      width: undefined,
+      padding: 0
     }
-  }, [windowWidth, parentPage, collectionView?.type, isMounted])
+  }, []) // Remove dependencies as we use defaults
 
   // console.log({
   //   width,
@@ -256,7 +258,7 @@ function CollectionViewTabs({
           className={cs(
             'notion-collection-view-tabs-content-item',
             collectionViewId === viewId &&
-              'notion-collection-view-tabs-content-item-active'
+            'notion-collection-view-tabs-content-item-active'
           )}
         >
           <CollectionViewColumnDesc


### PR DESCRIPTION
## Summary

Fix collection view layout to respect page content width instead of stretching to the full viewport.

## Changes

### 1. Remove manual width/padding calculations from collection views
The original JS-based width calculation (`containerWidth = window.innerWidth`) caused layout issues in pages with custom max-widths. This removes the manual calculations and lets CSS handle the layout.

### 2. Use `width: 100%` instead of `100vw` for table and board views
`.notion-table` and `.notion-board` used `width: 100vw` / `max-width: 100vw`, which made them stretch to the full viewport width, ignoring page margins. Changed to `width: 100%` / `max-width: 100%` so they respect their parent container.

### 3. Constrain `.notion-collection` wrapper
The `.notion-collection` wrapper had no `max-width` or `overflow` constraint, so tables with wide columns (floated content) would push it beyond the page container. Added `max-width: 100%` and `overflow: auto` to keep it within bounds while enabling horizontal scroll when content is wider.

### 4. Prevent gallery card shadow clipping
The `overflow: auto` on `.notion-collection` clips gallery card `box-shadow` at container edges. Added `padding: 4px` with compensating `margin: -4px` to give shadows room to render.

## Before / After

**Before:** Table views span full viewport width, ignoring page margins.
**After:** Table views respect page content width (same as galleries), with horizontal scroll for wide content.

## Files Changed

- `packages/react-notion-x/src/styles.css` — CSS layout fixes
- `packages/react-notion-x/src/third-party/collection.tsx` — Remove JS width calculations