### PR TITLE
fix: handle page_content_first gallery cover type for linked database views

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-card.tsx
+++ b/packages/react-notion-x/src/third-party/collection-card.tsx
@@ -33,7 +33,7 @@ export function CollectionCard({
   const coverPosition = (1 - page_cover_position) * 100
   const cardCoverPosition = (1 - card_cover_position) * 100
 
-  if (cover?.type === 'page_content') {
+  if (cover?.type === 'page_content' || cover?.type === 'page_content_first') {
     const contentBlockId = block.content?.find((blockId) => {
       const block = getBlockValue(recordMap.block[blockId])
 


### PR DESCRIPTION
## Summary

When a Notion page embeds a **linked view of a database** (as opposed to an inline database), the Notion API returns `gallery_cover.type` as `"page_content_first"` instead of `"page_content"`.

The `CollectionCard` component only checked for `"page_content"`, so linked database gallery cards rendered with empty covers even though the image data was correctly fetched and available in the `recordMap`.

## Fix

One-line change in `collection-card.tsx` to also match on `"page_content_first"`:

```diff
- if (cover?.type === 'page_content') {
+ if (cover?.type === 'page_content' || cover?.type === 'page_content_first') {
```

## How to reproduce

1. Create a Notion page with a **linked view** of a database (not an inline database)
2. Configure the gallery view to use "Page content" as the card cover
3. Render the page with react-notion-x — gallery cards will have empty covers

After this fix, the covers render correctly.