### PR TITLE
fix: respect hide_inline_collection_name for inline database views

### DIFF
--- a/packages/react-notion-x/src/third-party/collection.tsx
+++ b/packages/react-notion-x/src/third-party/collection.tsx
@@ -27,9 +27,9 @@ export function Collection({
   ctx
 }: {
   block:
-    | types.CollectionViewBlock
-    | types.CollectionViewPageBlock
-    | types.PageBlock
+  | types.CollectionViewBlock
+  | types.CollectionViewPageBlock
+  | types.PageBlock
   className?: string
   ctx: NotionContext
 }) {
@@ -184,7 +184,9 @@ function CollectionViewBlock({
 
   const title = getTextContent(collection.name).trim()
   const showTitle =
-    collectionView.format?.hide_linked_collection_name !== true && title
+    block.format?.hide_inline_collection_name !== true &&
+    collectionView.format?.hide_linked_collection_name !== true &&
+    title
   if (collection.icon) {
     block.format = {
       ...block.format,
@@ -250,7 +252,7 @@ function CollectionViewTabs({
           className={cs(
             'notion-collection-view-tabs-content-item',
             collectionViewId === viewId &&
-              'notion-collection-view-tabs-content-item-active'
+            'notion-collection-view-tabs-content-item-active'
           )}
         >
           <CollectionViewColumnDesc


### PR DESCRIPTION
## Summary

Notion uses two different properties to control collection title visibility depending on how the database is embedded:

- **Linked views**: `collectionView.format.hide_linked_collection_name`
- **Inline views**: `block.format.hide_inline_collection_name`

The current code only checks the view-level property (`hide_linked_collection_name`), so inline database views with "hide title" enabled still display the database name.

## Changes

**`packages/react-notion-x/src/third-party/collection.tsx`**

```diff
 const showTitle =
+    block.format?.hide_inline_collection_name !== true &&
     collectionView.format?.hide_linked_collection_name !== true &&
     title
```

The `block` prop is already available in the `Collection` component, so no additional data fetching is needed.

## Testing

Verified on a Notion page with three collection views:
- **Linked view** (hide title ON) — title correctly hidden ✅ (worked before)
- **Inline gallery** (hide title ON) — title now correctly hidden ✅ (was broken)
- **Inline table** (hide title ON) — title now correctly hidden ✅ (was broken)