### PR TITLE
fix: prevent page icons from being squashed in table cells

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1687,6 +1687,10 @@ svg.notion-page-icon {
   border-right: 0 none;
 }
 
+.notion-table-cell .notion-page-icon-inline {
+  flex-shrink: 0;
+}
+
 .notion-table-cell-title {
   font-weight: 500;
 }


### PR DESCRIPTION
## Problem

When a table cell title is very long, the flexbox layout compresses the inline page icon to a smaller size. This happens because `.notion-page-icon-inline` has no `flex-shrink` constraint, so the browser shrinks it to make room for the text.

## Fix

```css
.notion-table-cell .notion-page-icon-inline {
  flex-shrink: 0;
}
```

Prevents the icon from being compressed regardless of title length.

## Files Changed

- `packages/react-notion-x/src/styles.css` (+4 lines)
