### PR TITLE
fix: skip title property in list-view body to prevent duplicate text

### DIFF
--- a/packages/react-notion-x/src/third-party/collection-view-list.tsx
+++ b/packages/react-notion-x/src/third-party/collection-view-list.tsx
@@ -102,7 +102,7 @@ function List({
 
                 <div className='notion-list-item-body'>
                   {collectionView.format?.list_properties
-                    ?.filter((p: any) => p.visible)
+                    ?.filter((p: any) => p.visible && p.property !== 'title')
                     .map((p: any) => {
                       const schema = collection.schema[p.property]
                       const data =


### PR DESCRIPTION
## Problem

When `list_properties` in the collection view format includes the `title` property, the page title renders twice in list view items: once in the `.notion-list-item-title` header and again in the `.notion-list-item-body` properties section.

## Fix

Filter out the `title` property from the list body properties:

```diff
 {collectionView.format?.list_properties
-  ?.filter((p: any) => p.visible)
+  ?.filter((p: any) => p.visible && p.property !== 'title')
   .map((p: any) => {
```

The title is already rendered in the header section, so including it in the body is always a duplicate.

## Files Changed

- `packages/react-notion-x/src/third-party/collection-view-list.tsx` (+1 / -1)
