### PR TITLE
feat: abbreviate URLs in table cells with two-tone Notion-native display

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -1703,6 +1703,18 @@ svg.notion-page-icon {
   line-height: 1.5;
 }
 
+.notion-url-domain {
+  color: inherit;
+}
+
+.notion-url-path {
+  color: rgba(55, 53, 47, 0.45);
+}
+
+.dark-mode .notion-url-path {
+  color: rgba(255, 255, 255, 0.4);
+}
+
 .notion-table-cell-number {
   white-space: pre-wrap;
 }

--- a/packages/react-notion-x/src/third-party/property.tsx
+++ b/packages/react-notion-x/src/third-party/property.tsx
@@ -182,28 +182,55 @@ export function PropertyImpl(props: IPropertyProps) {
       function UrlProperty() {
         if (!data) return null
 
-        // TODO: refactor to less hacky solution
-        const d = structuredClone(data)
+        const rawUrl = data[0]?.[0]
+        if (!rawUrl) return null
 
-        if (inline) {
-          try {
-            const url = new URL(d[0]![0]!)
-            d[0]![0] = url.hostname.replace(/^www\./, '')
-          } catch {
-            // ignore invalid urls
+        // Parse the URL for two-tone abbreviated display
+        let domain = rawUrl
+        let path = ''
+        let fullUrl = rawUrl
+
+        try {
+          const url = new URL(rawUrl)
+          domain = url.hostname.replace(/^www\./, '')
+          const rawPath = url.pathname === '/' ? '' : url.pathname
+          fullUrl = url.href
+
+          // Abbreviate path with middle-truncation, matching Notion native
+          // e.g. /2026/01/26/nx-s1-5684190/news-iran-protests-internet
+          //    → /202...ternet
+          if (rawPath && rawPath.length > 20) {
+            const head = rawPath.slice(0, 8)
+            const tail = rawPath.slice(-8)
+            path = `${head}...${tail}`
+          } else {
+            path = rawPath
           }
+        } catch {
+          // For invalid URLs, render as-is
+          return (
+            <Text
+              value={data}
+              block={block!}
+              inline={inline}
+              linkProps={{
+                target: '_blank',
+                rel: 'noreferrer noopener'
+              }}
+            />
+          )
         }
 
         return (
-          <Text
-            value={d}
-            block={block!}
-            inline={inline}
-            linkProps={{
-              target: '_blank',
-              rel: 'noreferrer noopener'
-            }}
-          />
+          <a
+            href={fullUrl}
+            target='_blank'
+            rel='noreferrer noopener'
+            className='notion-link'
+          >
+            <span className='notion-url-domain'>{domain}</span>
+            {path && <span className='notion-url-path'>{path}</span>}
+          </a>
         )
       },
     [block, data, inline]


### PR DESCRIPTION
## Problem

URL properties in table cells currently show the full raw URL, which overflows and is hard to scan. Notion's native UI shows an abbreviated two-tone display: domain in normal color, path in a lighter muted color, with long paths middle-truncated.

## Solution

Replace the `Text` component rendering for URL properties with a direct `<a>` tag containing two styled spans:

- `<span class="notion-url-domain">` — domain in inherited text color (e.g., `npr.org`)
- `<span class="notion-url-path">` — path in muted color with middle-truncation (e.g., `/202...ternet`)

### URL abbreviation logic

```
Full:     https://www.npr.org/2026/01/26/nx-s1-5684190/news-iran-protests-internet
Rendered: npr.org/202...ternet
          ───────┬─────────────
          domain  abbreviated path (head 8 + ... + tail 8)
```

Falls back to `Text` component rendering for invalid URLs that fail `new URL()` parsing.

### Dark mode support

```css
.notion-url-path {
  color: rgba(55, 53, 47, 0.45);
}
.dark-mode .notion-url-path {
  color: rgba(255, 255, 255, 0.4);
}
```

## Files Changed

- `packages/react-notion-x/src/third-party/property.tsx` (+45 / -18)
- `packages/react-notion-x/src/styles.css` (+12)
