### PR TITLE
fix: use components.Link for inline text links to prevent nested anchors

### DIFF
--- a/packages/react-notion-x/src/components/text.tsx
+++ b/packages/react-notion-x/src/components/text.tsx
@@ -68,12 +68,12 @@ export function Text({
                 // console.log('p', blockId)
 
                 return (
-                  <components.PageLink
+                  <components.Link
                     className='notion-link'
                     href={mapPageUrl(blockId)}
                   >
                     <PageTitle block={linkedBlock} />
-                  </components.PageLink>
+                  </components.Link>
                 )
               }
 
@@ -116,7 +116,7 @@ export function Text({
                     }
 
                     return (
-                      <components.PageLink
+                      <components.Link
                         className='notion-link'
                         href={mapPageUrl(id)}
                         {...linkProps}
@@ -124,7 +124,7 @@ export function Text({
                         rel='noopener noreferrer'
                       >
                         <PageTitle block={linkedBlock} />
-                      </components.PageLink>
+                      </components.Link>
                     )
                   }
                 }
@@ -174,13 +174,13 @@ export function Text({
                       : `${mapPageUrl(id!)}${getHashFragmentValue(v)}`
 
                   return (
-                    <components.PageLink
+                    <components.Link
                       className='notion-link'
                       href={href}
                       {...linkProps}
                     >
                       {element}
-                    </components.PageLink>
+                    </components.Link>
                   )
                 } else {
                   return (


### PR DESCRIPTION
## Problem

When `components.PageLink` is overridden (e.g., to render a custom `<div>` container instead of `<a>`), the inline text decorators in `text.tsx` create nested DOM issues. Specifically, the `'p'` (page mention), `'‣'` (cross-workspace link), and `'a'` (internal URL) decorators all use `components.PageLink`, which means:

1. Inline page mentions inside a `PageLink`-wrapped title cell create a `PageLink` inside a `PageLink` (nested containers)
2. If the outer `PageLink` renders as `<a>`, this produces invalid `<a>` inside `<a>` HTML, causing React hydration errors

These inline text links are semantically different from block-level page links — they appear *within* text content and should behave as simple navigation links, not as page-level containers.

## Fix

Changed the three inline text decorators from `components.PageLink` to `components.Link`:

| Decorator | Purpose | Before | After |
|-----------|---------|--------|-------|
| `'p'` | Inline page mention (@Page Name) | `components.PageLink` | `components.Link` |
| `'‣'` | Cross-workspace page link | `components.PageLink` | `components.Link` |
| `'a'` | Internal URL recognized as page link | `components.PageLink` | `components.Link` |

This preserves the existing behavior for custom `Link` overrides while preventing nesting issues with custom `PageLink` overrides.

## Files Changed

- `packages/react-notion-x/src/components/text.tsx` — 6 lines changed (3 opening tags + 3 closing tags)
