### PR TITLE
fix: use getBlockValue for automation/action lookups in button component

### DIFF
--- a/packages/react-notion-x/src/components/button.tsx
+++ b/packages/react-notion-x/src/components/button.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { useNotionContext } from '../context'
 import { cs } from '../utils'
+import { getBlockValue } from 'notion-utils'
 import { Text } from './text'
 
 interface AutomationValue {
@@ -78,10 +79,11 @@ export function Button({
     )
   }
 
-  // Get automation data
-  const automation = (recordMap as any).automation?.[automationId]?.value as
-    | AutomationValue
-    | undefined
+  // Get automation data — use getBlockValue to handle double-nested
+  // value.value format from the Notion API
+  const automation = getBlockValue(
+    (recordMap as any).automation?.[automationId]
+  ) as AutomationValue | undefined
 
   if (!automation) {
     // Fallback to title if no automation found
@@ -126,8 +128,9 @@ export function Button({
       return
     }
 
-    const actionData = (recordMap as any).automation_action?.[firstActionId]
-      ?.value as AutomationActionValue | undefined
+    const actionData = getBlockValue(
+      (recordMap as any).automation_action?.[firstActionId]
+    ) as AutomationActionValue | undefined
     if (!actionData) {
       console.warn('No action data found for ID:', firstActionId)
       return


### PR DESCRIPTION
### Problem
When rendering a Notion button block that has an automation or automation action, the button text fails to resolve correctly and falls back to rendering the generic text `"button"`.

This occurs because the Notion API returns automations and actions in the `recordMap` double-wrapped under `value.value`. The button component was accessing `recordMap.automation[id]?.value` and `recordMap.automation_action[id]?.value` directly. Because only one level of nesting was peeled off, the custom label/text properties (such as `.title` or `.name`) were missing at that level, causing the fallback to be used.

### Solution
Use the helper function `getBlockValue` (which recursively unwraps nested `.value` properties) instead of direct `.value` access.

### Files Changed
* `packages/react-notion-x/src/components/button.tsx`
