### PR TITLE
fix: use getBlockValue for collection_view lookup in getPage

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -175,8 +175,9 @@ export class NotionAPI {
         allCollectionInstances,
         async (collectionInstance) => {
           const { collectionId, collectionViewId, spaceId } = collectionInstance
-          const collectionView =
-            recordMap.collection_view[collectionViewId]?.value
+          const collectionView = getBlockValue(
+            recordMap.collection_view[collectionViewId]
+          )
 
           try {
             const collectionData = await this.getCollectionData(


### PR DESCRIPTION
### Problem
In `packages/notion-client/src/notion-api.ts`'s `getPage()`, the code was retrieving the `collectionView` using `recordMap.collection_view[collectionViewId]?.value`.

Because Notion's API wraps collection view records with a double-nested `value.value` structure (similar to other record types like blocks and collections), this single-level access only retrieved the wrapper object rather than the actual view data.

Consequently:
- `collectionView.query2` was `undefined`.
- Sort settings and filters were ignored when building the query for `getCollectionData`.
- `collectionView.type` and `collectionView.format` were `undefined`, breaking grouping and type detection for board/gallery/etc views inside `getCollectionData`.

Note that commit `a64dfb9` ("feat: re-enable examples/demos locally") systematically converted raw `.value` accesses to `getBlockValue()` across `notion-api.ts` for blocks and collections, but missed this single instance for `collection_view`.

### Solution
Replace the raw `.value` access with `getBlockValue()`:
```typescript
const collectionView = getBlockValue(recordMap.collection_view[collectionViewId])
```

### Files Changed
* `packages/notion-client/src/notion-api.ts`
