### PR TITLE
feat(examples/full): add image proxy fallback for firewall environments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,179 @@
+# Changes vs. Upstream (NotionX/react-notion-x)
+
+This document summarizes additions and modifications made in this fork (`jack-h-park/react-notion-x`) relative to the upstream repository ([NotionX/react-notion-x](https://github.com/NotionX/react-notion-x)).
+
+> Baseline: `upstream/master`  
+> Known fork branches: `origin/main`, `origin/feat/text-thumbnail-preview`, `origin/claude/infallible-lovelace`
+
+---
+
+## 1. Gallery Card Cover — Text Thumbnail Teaser
+
+Generates a text-based thumbnail from page content for gallery cards that have no image. Reproduces the Notion app's `page_content` / `page_content_first` cover type behavior.
+
+### New file: `collection-card-cover.ts`
+
+- **Location**: `packages/react-notion-x/src/third-party/collection-card-cover.ts` (669 lines)
+- **Main export**: `getCollectionCardCoverCandidate()`
+
+**Return type (`CollectionCardCoverCandidate`)**
+
+| kind | Description |
+|------|-------------|
+| `image` | Image URL + alt + objectPosition |
+| `teaser` | Text-based thumbnail (eyebrow / title / body / icon + tone) |
+| `empty` | No cover |
+
+**Image candidate search logic**
+
+1. Traverses direct child blocks of the page (BFS, up to 16 blocks)
+2. Transparent containers (`column_list`, `column`, `synced_block`, etc.) are recursed into
+3. `image` block → used directly
+4. `video` block → used if `display_source` is an image URL
+5. `pdf` / `file` block → used if registered in the `preview_images` map
+6. Nested `page` / `collection_view_page` blocks are skipped
+
+**Text teaser construction logic**
+
+When no image is found, a teaser is built from text blocks:
+
+- **tone classification**
+  - `callout` → prominent callout style
+  - `quote` → blockquote style
+  - `default` → plain text style
+- **eyebrow**: short label (heading, callout title, etc.). Metadata-like text (`KEY: value` patterns) and weak headings (`overview`, `summary`, etc.) are excluded
+- **title**: first meaningful heading in the page. Suppressed if it duplicates the page title
+- **body**: up to 3 meaningful text blocks, capped at 240 characters
+- **icon**: emoji/icon from a callout block (URL-format icons are excluded)
+- `genericEyebrowTexts` (executive summary, overview, etc.) suppress the eyebrow if there is no body
+
+**Helper functions**
+
+| Function | Role |
+|----------|------|
+| `traversePageContent` | Full page block traversal with a visited-set |
+| `getFlattenedPreviewBlocks` | BFS extraction of up to 16 preview blocks |
+| `getLoadedDescendantBlocks` | Extract child blocks from callout/toggle |
+| `resolveVisualCandidate` | Build an image candidate from a single block |
+| `buildTeaserCandidate` | Analyze text blocks and build a teaser candidate |
+| `getCalloutOrToggleTexts` | Extract eyebrow/body from callout/toggle |
+| `getMeaningfulTextParts` | Collect up to N meaningful text parts |
+| `shouldSuppressTeaserTitle` | Determine if teaser title duplicates the page title |
+| `finalizeTeaserCandidate` | Finalize teaser candidate (suppress generic eyebrow, etc.) |
+| `clipText` | Clip text to maxChars and append `…` |
+| `isMetadataLikeText` | Detect `KEY: value` patterns |
+| `isImageLikeUrl` | Determine if a URL points to an image (by extension/domain) |
+| `hasPreviewImage` | Check if a URL is registered in `recordMap.preview_images` |
+
+### Tests: `collection-card-cover.test.ts`
+
+- **Location**: `packages/react-notion-x/src/third-party/collection-card-cover.test.ts` (659 lines)
+- Vitest-based unit tests
+- Covers: direct image, nested container image, video preview, callout teaser, quote teaser, page title deduplication suppression, generic eyebrow handling, and more
+
+### `collection-card.tsx` changes
+
+- Calls `getCollectionCardCoverCandidate()` and branches on `candidate.kind`:
+  - `image` → existing `<LazyImage>` rendering
+  - `teaser` → `<CollectionCardCoverTeaser>` rendering (new)
+  - `empty` → no cover area
+
+---
+
+## 2. Button Block Improvements
+
+- **Location**: `packages/react-notion-x/src/components/button.tsx`
+
+**Changes**
+
+| Item | Description |
+|------|-------------|
+| Icon rendering | Renders the automation's `properties.icon` before the button label as `<span class="notion-button-icon">` |
+| `open_page` action | Supports both `target.page.id` (new API) and `target.pageId` (old API) |
+| Buttons without automation | Rendered with the `<Text>` component instead of `getTextContent()` (rich text support) |
+| Import order | Import order cleaned up to satisfy ESLint rules |
+
+---
+
+## 3. Quote Block Fix
+
+- **Location**: `packages/react-notion-x/src/block.tsx`
+
+**Change**
+
+```
+// Before
+if (!block.properties) return null
+
+// After
+if (!block.properties && !children) return null
+```
+
+When a Notion quote block's text lives in **child blocks** rather than `properties.title`, the old code skipped the block entirely. Now the block renders as long as it has children, even when `properties` is absent.
+
+---
+
+## 4. New CSS Styles
+
+- **Location**: `packages/react-notion-x/src/styles.css`
+
+**Teaser thumbnail styles** (for gallery card covers)
+
+| Class | Role |
+|-------|------|
+| `.notion-collection-card-cover-teaser` | Full area without border, 18px padding |
+| `.notion-collection-card-cover-teaser-panel` | Flex column layout, 6px gap |
+| `.notion-collection-card-cover-teaser-panel-callout` | Callout variant, 10px gap |
+| `.notion-collection-card-cover-teaser-panel-quote` | 3px left border + padding |
+| `.notion-collection-card-cover-teaser-eyebrow` | 11px, uppercase, 1-line clamp |
+| `.notion-collection-card-cover-teaser-title` | 600 weight, 15px, 3-line clamp |
+| `.notion-collection-card-cover-teaser-body` | 13px, multi-line clamp |
+| `.notion-collection-card-cover-teaser-icon` | Fixed flex, 17px |
+
+**Button dark-mode styles**
+
+| Class | Role |
+|-------|------|
+| `.notion-button-icon` | Button icon spacing |
+| `.dark-mode .notion-button:hover` | Dark-mode hover color |
+| `.dark-mode .notion-button:active` | Dark-mode active color |
+| `.dark-mode .notion-button.notion-default:hover` | Dark-mode default button hover |
+| `.dark-mode .notion-button.notion-default:active` | Dark-mode default button active |
+
+---
+
+## 5. notion-client API Improvements
+
+- **Location**: `packages/notion-client/src/notion-api.ts`
+
+**Changes**
+
+| Item | Description |
+|------|-------------|
+| `automation` / `automation_action` initialization | Initializes as empty objects when the maps are absent from `recordMap` |
+| `getAllContentBlockIds()` new method | Collects content block IDs from both regular pages and collection sub-pages |
+| `getCollectionPageIds()` new method | Returns a list of collection page block IDs from `recordMap` |
+| Signed URL scope expanded | `addSignedUrls` call now includes collection sub-page blocks |
+
+---
+
+## 6. Packaging — Direct GitHub Tarball Install Support
+
+Upstream only supports npm distribution. This fork modifies the package structure to allow installing directly from the GitHub repository as an npm dependency (`github:jack-h-park/react-notion-x#tag`).
+
+**Changes**
+
+| File | Change |
+|------|--------|
+| `package.json` (root) | Configured root to act as the `react-notion-x` package (added `main`, `exports`) |
+| `packages/react-notion-x/package.json` | `build/` output included in `exports`, `prepare` script removed |
+| `packages/react-notion-x/build/` | Build artifacts (`index.js`, `third-party/*.js`, `.d.ts`) committed to the repository |
+
+**Release tag naming convention**
+
+```
+7.10.0-jp.1 ~ 7.10.0-jp.8   (latest: jp.8)
+7.7.1-jp.2, 7.7.1-jp.3
+```
+
+The `-jp.N` suffix distinguishes fork releases from upstream versions.

--- a/examples/full/components/NotionImage.tsx
+++ b/examples/full/components/NotionImage.tsx
@@ -1,0 +1,72 @@
+import Image from 'next/image'
+import { useState } from 'react'
+
+type Props = {
+  src: string
+  alt?: string
+  width?: number | string
+  height?: number | string
+  className?: string
+  objectFit?: React.CSSProperties['objectFit']
+  objectPosition?: React.CSSProperties['objectPosition']
+  layout?: 'fill' | 'intrinsic' | 'fixed' | 'responsive'
+  [key: string]: unknown
+}
+
+// next/image(legacy) 전용 props는 일반 <img>에 전달하지 않음
+const NEXT_IMAGE_ONLY_PROPS = new Set(['layout', 'objectFit', 'objectPosition'])
+
+export function NotionImage({
+  src,
+  alt = '',
+  width,
+  height,
+  className,
+  objectFit,
+  objectPosition,
+  layout,
+  ...rest
+}: Props) {
+  const [useFallback, setUseFallback] = useState(false)
+
+  // next/image(legacy)로 fallback
+  if (useFallback) {
+    return (
+      <Image
+        src={src}
+        alt={alt}
+        width={layout === 'intrinsic' && width ? Number(width) : undefined}
+        height={layout === 'intrinsic' && height ? Number(height) : undefined}
+        fill={!width || !height || layout === 'fill'}
+        className={className}
+        style={{ objectFit, objectPosition }}
+      />
+    )
+  }
+
+  // layout prop을 CSS로 변환
+  const imgStyle: React.CSSProperties = { objectFit, objectPosition }
+  if (layout === 'fill') {
+    imgStyle.position = 'absolute'
+    imgStyle.width = '100%'
+    imgStyle.height = '100%'
+  }
+
+  // next/image 전용 props 제거 후 <img>에 전달
+  const safeRest = Object.fromEntries(
+    Object.entries(rest).filter(([key]) => !NEXT_IMAGE_ONLY_PROPS.has(key))
+  )
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={className}
+      style={imgStyle}
+      onError={() => setUseFallback(true)}
+      {...safeRest}
+    />
+  )
+}

--- a/examples/full/components/NotionPage.tsx
+++ b/examples/full/components/NotionPage.tsx
@@ -1,6 +1,5 @@
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
-// import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { type ExtendedRecordMap } from 'notion-types'
@@ -9,6 +8,7 @@ import { NotionRenderer } from 'react-notion-x'
 import TweetEmbed from 'react-tweet-embed'
 
 import { Loading } from './Loading'
+import { NotionImage } from './NotionImage'
 
 // -----------------------------------------------------------------------------
 // dynamic imports for optional components
@@ -205,8 +205,7 @@ export function NotionPage({
         rootPageId={rootPageId}
         previewImages={previewImagesEnabled}
         components={{
-          // NOTE (transitive-bullshit 3/12/2023): I'm disabling next/image for this repo for now because the amount of traffic started costing me hundreds of dollars a month in Vercel image optimization costs. I'll probably re-enable it in the future if I can find a better solution.
-          // nextLegacyImage: Image,
+          nextLegacyImage: NotionImage,
           nextLink: Link,
           Code,
           Collection,

--- a/examples/full/next.config.js
+++ b/examples/full/next.config.js
@@ -1,13 +1,14 @@
 export default {
   staticPageGenerationTimeout: 300,
   images: {
-    domains: [
-      'www.notion.so',
-      'notion.so',
-      'images.unsplash.com',
-      'abs.twimg.com',
-      'pbs.twimg.com',
-      's3.us-west-2.amazonaws.com'
+    remotePatterns: [
+      { protocol: 'https', hostname: 'www.notion.so' },
+      { protocol: 'https', hostname: 'notion.so' },
+      { protocol: 'https', hostname: 'img.notionusercontent.com' },
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'abs.twimg.com' },
+      { protocol: 'https', hostname: 'pbs.twimg.com' },
+      { protocol: 'https', hostname: '*.amazonaws.com' }
     ],
     formats: ['image/avif', 'image/webp']
   }


### PR DESCRIPTION
## Summary

- Add `NotionImage` component that loads images directly from notion.so and automatically falls back to Next.js `next/image` proxy on error (`onError`)
- Upgrade `next.config.js` from deprecated `domains` to `remotePatterns`, add `img.notionusercontent.com` and `*.amazonaws.com` wildcard
- Replace `nextLegacyImage` in `NotionPage.tsx` with the new `NotionImage` component

## Motivation

In environments where notion.so is blocked by a firewall, browsers cannot load images directly. This PR implements a fallback strategy: images are fetched directly from notion.so in normal environments (no extra cost), and only fall back to a server-side proxy (`/_next/image`) when the direct request fails.

## How it works

```
Browser → <img src="notion.so/image/...">
          ├── success → render as-is (no Vercel image optimization charge)
          └── failure → onError → <Image> (next/image proxy)
                                  → server fetches from notion.so on behalf of client
```

## Test plan

- [ ] Without firewall: confirm images load directly from notion.so (check Network tab for `www.notion.so` requests)
- [ ] With firewall (or block notion.so in DevTools): confirm `onError` triggers and requests are retried via `/_next/image?url=...`
- [ ] Verify `fill` layout images render correctly
- [ ] Verify `intrinsic` layout images apply width/height correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)