### PR TITLE
fix Spotify <iframe> embed overflows on notion two-column layout

### DIFF
--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -148,7 +148,7 @@
   font-family: var(--notion-font);
 }
 
-.notion > * {
+.notion>* {
   padding: 3px 0;
 }
 
@@ -232,8 +232,7 @@
   line-height: 1;
 }
 
-.notion-aside-table-of-contents
-  .notion-table-of-contents-item-indent-level-0:first-of-type {
+.notion-aside-table-of-contents .notion-table-of-contents-item-indent-level-0:first-of-type {
   margin-top: 0;
 }
 
@@ -308,89 +307,115 @@
 .notion-red_co {
   color: var(--notion-red);
 }
+
 .notion-pink,
 .notion-pink_co {
   color: var(--notion-pink);
 }
+
 .notion-blue,
 .notion-blue_co {
   color: var(--notion-blue);
 }
+
 .notion-purple,
 .notion-purple_co {
   color: var(--notion-purple);
 }
+
 .notion-teal,
 .notion-teal_co {
   color: var(--notion-teal);
 }
+
 .notion-yellow,
 .notion-yellow_co {
   color: var(--notion-yellow);
 }
+
 .notion-orange,
 .notion-orange_co {
   color: var(--notion-orange);
 }
+
 .notion-brown,
 .notion-brown_co {
   color: var(--notion-brown);
 }
+
 .notion-gray,
 .notion-gray_co {
   color: var(--notion-gray);
 }
+
 .notion-red_background {
   background-color: var(--notion-red_background);
 }
+
 .notion-pink_background {
   background-color: var(--notion-pink_background);
 }
+
 .notion-blue_background {
   background-color: var(--notion-blue_background);
 }
+
 .notion-purple_background {
   background-color: var(--notion-purple_background);
 }
+
 .notion-teal_background {
   background-color: var(--notion-teal_background);
 }
+
 .notion-yellow_background {
   background-color: var(--notion-yellow_background);
 }
+
 .notion-orange_background {
   background-color: var(--notion-orange_background);
 }
+
 .notion-brown_background {
   background-color: var(--notion-brown_background);
 }
+
 .notion-gray_background {
   background-color: var(--notion-gray_background);
 }
+
 .notion-red_background_co {
   background-color: var(--notion-red_background_co);
 }
+
 .notion-pink_background_co {
   background-color: var(--notion-pink_background_co);
 }
+
 .notion-blue_background_co {
   background-color: var(--notion-blue_background_co);
 }
+
 .notion-purple_background_co {
   background-color: var(--notion-purple_background_co);
 }
+
 .notion-teal_background_co {
   background-color: var(--notion-teal_background_co);
 }
+
 .notion-yellow_background_co {
   background-color: var(--notion-yellow_background_co);
 }
+
 .notion-orange_background_co {
   background-color: var(--notion-orange_background_co);
 }
+
 .notion-brown_background_co {
   background-color: var(--notion-brown_background_co);
 }
+
 .notion-gray_background_co {
   background-color: var(--notion-gray_background_co);
 }
@@ -399,39 +424,48 @@
   background-color: var(--notion-item-blue);
   color: var(--notion-item-text-blue);
 }
+
 .notion-item-orange {
   background-color: var(--notion-item-orange);
   color: var(--notion-item-text-orange);
 }
+
 .notion-item-green {
   background-color: var(--notion-item-green);
   color: var(--notion-item-text-green);
 }
+
 .notion-item-pink {
   background-color: var(--notion-item-pink);
   color: var(--notion-item-text-pink);
 }
+
 .notion-item-brown {
   background-color: var(--notion-item-brown);
   color: var(--notion-item-text-brown);
 }
+
 .notion-item-red {
   background-color: var(--notion-item-red);
   color: var(--notion-item-text-red);
 }
+
 .notion-item-yellow {
   background-color: var(--notion-item-yellow);
   color: var(--notion-item-text-yellow);
 }
+
 .notion-item-default,
 .notion-item-default-inferred {
   background-color: var(--notion-item-default);
   color: var(--notion-item-text-default);
 }
+
 .notion-item-purple {
   background-color: var(--notion-item-purple);
   color: var(--notion-item-text-purple);
 }
+
 .notion-item-gray {
   background-color: var(--notion-item-gray);
   color: var(--notion-item-text-gray);
@@ -440,33 +474,43 @@
 .notion-item-bullet-blue {
   background-color: var(--notion-item-bullet-blue);
 }
+
 .notion-item-bullet-orange {
   background-color: var(--notion-item-bullet-orange);
 }
+
 .notion-item-bullet-green {
   background-color: var(--notion-item-bullet-green);
 }
+
 .notion-item-bullet-pink {
   background-color: var(--notion-item-bullet-pink);
 }
+
 .notion-item-bullet-brown {
   background-color: var(--notion-item-bullet-brown);
 }
+
 .notion-item-bullet-red {
   background-color: var(--notion-item-bullet-red);
 }
+
 .notion-item-bullet-yellow {
   background-color: var(--notion-item-bullet-yellow);
 }
+
 .notion-item-bullet-default {
   background-color: var(--notion-item-bullet-default);
 }
+
 .notion-item-bullet-default-inferred {
   background-color: var(--notion-item-bullet-gray);
 }
+
 .notion-item-bullet-purple {
   background-color: var(--notion-item-bullet-purple);
 }
+
 .notion-item-bullet-gray {
   background-color: var(--notion-item-bullet-gray);
 }
@@ -509,16 +553,18 @@
   left: 0;
 }
 
-.notion-title + .notion-h1,
-.notion-title + .notion-h2,
-.notion-title + .notion-h3,
-.notion-title + .notion-h4 {
+.notion-title+.notion-h1,
+.notion-title+.notion-h2,
+.notion-title+.notion-h3,
+.notion-title+.notion-h4 {
   margin-top: 0;
 }
+
 /* TODO: notion-page-content */
 .notion-h1:first-child {
   margin-top: 0;
 }
+
 /* .notion-h1:first-of-type {
   margin-top: 2px;
 } */
@@ -526,10 +572,12 @@
   font-size: 1.5em;
   margin-top: 1.1em;
 }
+
 .notion-h3 {
   font-size: 1.25em;
   margin-top: 1em;
 }
+
 .notion-h4 {
   font-size: 1.15em;
   margin-top: 1em;
@@ -817,6 +865,7 @@ svg.notion-page-icon {
   margin: 0;
   transition: unset;
 }
+
 .notion-collection-card .notion-page-link {
   background: unset;
 }
@@ -864,6 +913,7 @@ svg.notion-page-icon {
   margin-top: 0;
   margin-bottom: 0;
 }
+
 .notion-list-numbered {
   list-style-type: decimal;
   padding-inline-start: 1.6em;
@@ -910,6 +960,11 @@ svg.notion-page-icon {
 .notion-asset-wrapper iframe {
   border: none;
   background: rgb(247, 246, 245);
+}
+
+.notion-asset-wrapper-embed>div {
+  width: 100% !important;
+  max-width: 100% !important;
 }
 
 .notion-text {
@@ -1016,7 +1071,7 @@ svg.notion-page-icon {
   font-size: 14px;
 }
 
-.notion-code-copy-tooltip > div {
+.notion-code-copy-tooltip>div {
   padding: 6px 8px;
   background: #222;
   color: #fff;
@@ -1030,13 +1085,13 @@ svg.notion-page-icon {
   padding-bottom: 12px;
 }
 
-.notion-column > *:first-child {
+.notion-column>*:first-child {
   margin-top: 0;
   margin-left: 0;
   margin-right: 0;
 }
 
-.notion-column > *:last-child {
+.notion-column>*:last-child {
   margin-left: 0;
   margin-right: 0;
   margin-bottom: 0;
@@ -1079,7 +1134,7 @@ svg.notion-page-icon {
   border-color: var(--bg-color-0);
 }
 
-.notion-bookmark > div:first-child {
+.notion-bookmark>div:first-child {
   flex: 4 1 180px;
   padding: 12px 14px 14px;
   overflow: hidden;
@@ -1136,7 +1191,7 @@ svg.notion-page-icon {
   position: relative;
 }
 
-.notion-bookmark-image > * {
+.notion-bookmark-image>* {
   position: absolute !important;
   width: 100%;
   height: 100%;
@@ -1218,7 +1273,7 @@ svg.notion-page-icon {
   width: 100%;
 }
 
-.notion-callout-text > *:first-child {
+.notion-callout-text>*:first-child {
   margin-top: 0;
   padding-top: 0;
 }
@@ -1227,11 +1282,13 @@ svg.notion-page-icon {
   width: 100%;
   padding: 3px 2px;
 }
-.notion-toggle > summary {
+
+.notion-toggle>summary {
   cursor: pointer;
   outline: none;
 }
-.notion-toggle > div {
+
+.notion-toggle>div {
   margin-left: 1.1em;
 }
 
@@ -2124,15 +2181,11 @@ svg.notion-page-icon {
   height: 148px;
 }
 
-.notion-board-view-size-small
-  .notion-collection-card
-  .notion-collection-card-cover {
+.notion-board-view-size-small .notion-collection-card .notion-collection-card-cover {
   height: 100px;
 }
 
-.notion-board-view-size-large
-  .notion-collection-card
-  .notion-collection-card-cover {
+.notion-board-view-size-large .notion-collection-card .notion-collection-card-cover {
   height: 180px;
 }
 
@@ -2404,7 +2457,7 @@ svg.notion-page-icon {
   padding-right: 32px;
 }
 
-.notion-frame .katex > .katex-html {
+.notion-frame .katex>.katex-html {
   white-space: normal;
 }
 
@@ -2453,9 +2506,7 @@ svg.notion-page-icon {
   border-bottom: 0 none;
 }
 
-.notion-collection-card-property
-  .notion-property-relation
-  .notion-page-title-text {
+.notion-collection-card-property .notion-property-relation .notion-page-title-text {
   border-bottom: 1px solid;
 }
 
@@ -2527,9 +2578,7 @@ svg.notion-page-icon {
   border-bottom: 0 none;
 }
 
-.notion-collection-row-property
-  .notion-property-relation
-  .notion-page-title-text {
+.notion-collection-row-property .notion-property-relation .notion-page-title-text {
   border-bottom: 1px solid;
 }
 
@@ -2999,10 +3048,9 @@ svg.notion-page-icon {
   margin-bottom: 1em;
 }
 
-.notion-collection-group > summary {
-}
+.notion-collection-group>summary {}
 
-.notion-collection-group > summary > div {
+.notion-collection-group>summary>div {
   transform: scale(0.85);
   transform-origin: 0% 50%;
   display: inline-flex;
@@ -3161,6 +3209,7 @@ svg.notion-page-icon {
 .notion-preview-card-domain-warp .notion-preview-card-domain {
   padding-left: 4px;
 }
+
 .notion-preview-card-domain-warp .notion-preview-card-logo {
   width: 14px;
   height: 14px;
@@ -3205,13 +3254,14 @@ svg.notion-page-icon {
   transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
 
-.notion-yt-lite > iframe {
+.notion-yt-lite>iframe {
   width: 100%;
   height: 100%;
   position: absolute;
   top: 0;
   left: 0;
 }
+
 .notion-yt-playbtn {
   width: 68px;
   height: 48px;
@@ -3228,7 +3278,8 @@ svg.notion-page-icon {
   transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
   border: none;
 }
-.notion-yt-lite:hover > .notion-yt-playbtn,
+
+.notion-yt-lite:hover>.notion-yt-playbtn,
 .notion-yt-youtube .notion-yt-playbtn:focus {
   filter: none;
 }
@@ -3236,8 +3287,9 @@ svg.notion-page-icon {
 .notion-yt-initialized {
   cursor: unset;
 }
+
 .notion-yt-initialized::before,
-.notion-yt-initialized > .notion-yt-playbtn {
+.notion-yt-initialized>.notion-yt-playbtn {
   opacity: 0;
   pointer-events: none;
 }
@@ -3508,20 +3560,16 @@ svg.notion-page-icon {
 
 .notion-tab-scroll-fade-left {
   left: 0;
-  background: linear-gradient(
-    to right,
-    var(--bg-color) 0%,
-    rgba(0, 0, 0, 0) 100%
-  );
+  background: linear-gradient(to right,
+      var(--bg-color) 0%,
+      rgba(0, 0, 0, 0) 100%);
 }
 
 .notion-tab-scroll-fade-right {
   right: 0;
-  background: linear-gradient(
-    to left,
-    var(--bg-color) 0%,
-    rgba(0, 0, 0, 0) 100%
-  );
+  background: linear-gradient(to left,
+      var(--bg-color) 0%,
+      rgba(0, 0, 0, 0) 100%);
 }
 
 .notion-tab-scroll {

--- a/packages/react-notion-x/src/styles.css
+++ b/packages/react-notion-x/src/styles.css
@@ -959,7 +959,7 @@ svg.notion-page-icon {
 
 .notion-asset-wrapper iframe {
   border: none;
-  background: rgb(247, 246, 245);
+  background: transparent;
 }
 
 .notion-asset-wrapper-embed>div {


### PR DESCRIPTION
**Description**
Currently, embed containers (such as Spotify <iframe> embeds) suffer from overflow issues because their width is hardcoded to 600px. This causes the embed to break out of its parent container when placed in constrained spaces, such as within a narrow two-column layout.

**Solution**
Updated the CSS for .notion-asset-wrapper-embed > div to use fluid width constraints, the embed wrapper now scales dynamically and properly respects the boundaries of its parent container. 

Update iframe background to transparent to prevent white corners on rounded edges in dark mode

**Before**
<img width="671" height="253" alt="Screenshot 2026-07-12 at 12 45 11" src="https://github.com/user-attachments/assets/35700efb-5e6b-47c4-a22e-945ae1dd2f15" />


<img width="689" height="242" alt="Screenshot 2026-07-12 at 12 46 10" src="https://github.com/user-attachments/assets/180a9a9c-46b3-495a-8dff-7d27bb60cf7a" />


**After**
<img width="362" height="237" alt="Screenshot 2026-07-12 at 13 16 15" src="https://github.com/user-attachments/assets/c4a2f89d-61ee-4e13-93c9-517bee8aeb5e" />
