### PR TITLE
fix(notion-client): update default value for apiBaseUrl

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -24,14 +24,14 @@ export class NotionAPI {
   /**
    * Constructor for the NotionAPI class.
    * @param options - Configuration options.
-   * @param options.apiBaseUrl - The base URL of the Notion API. Defaults to `https://www.notion.so/api/v3`.
+   * @param options.apiBaseUrl - The base URL of the Notion API. Defaults to `https://app.notion.com/api/v3`.
    * @param options.authToken - The authentication token for the Notion API. Defaults to undefined.
    * @param options.activeUser - The active user for the Notion API. Defaults to undefined.
    * @param options.userTimeZone - The time zone for the Notion API. Defaults to `America/New_York`.
    * @param options.ofetchOptions - The HTTP options to use for the underlying `ofetch` requests. Defaults to undefined.
    */
   constructor({
-    apiBaseUrl = 'https://www.notion.so/api/v3',
+    apiBaseUrl = 'https://app.notion.com/api/v3',
     authToken,
     activeUser,
     userTimeZone = 'America/New_York',


### PR DESCRIPTION
#### Description

This is a follow-up to #710. Since Aug 2026 requets to `https://www.notion.so/api/v3` were returning 403. For that domain to work requests would need to include a `User-Agent`.

As suggested in the original issue, we have upadted the base domain (which doens't seem to have the same UA requirements).

#### Notion Test Page ID

Any page really:
- https://app.notion.com/p/saasifysh/Embeds-5d4e290ca4604d8fb809af806a6c1749