### PR TITLE
feat(notion-client): send default User-Agent

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -823,6 +823,8 @@ export class NotionAPI {
     headers?: any
   }): Promise<T> {
     const headers: any = {
+      'User-Agent':
+        'notion-client (+https://github.com/NotionX/react-notion-x)',
       ...clientHeaders,
       ...this._ofetchOptions?.headers,
       ...ofetchOptions?.headers,


### PR DESCRIPTION
#### Description

This is a follow-up to #710. Since Aug 2026 requets to `https://www.notion.so/api/v3` were returning 403 for any request that does not include a `User-Agent`.

#### Notion Test Page ID

Any page really:
- https://app.notion.com/p/saasifysh/Embeds-5d4e290ca4604d8fb809af806a6c1749